### PR TITLE
Integrate Svelte 5 runes with Flourish template

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "singleQuote": true,
+  "semi": true,
+  "tabWidth": 2,
+  "trailingComma": "es5"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,25 +1,25 @@
 {
-  "name": "flourish-template-svelte-5: 
-  "version": "0.0.0: 
+  "name": "flourish-template-svelte-5",
+  "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "flourish-template-svelte-5: 
-      "version": "0.0.0: 
+      "name": "flourish-template-svelte-5",
+      "version": "0.0.0",
       "devDependencies": {
-        "@sveltejs/vite-plugin-svelte": "^4.0.0: 
-        "svelte": "^5.1.3: 
+        "@sveltejs/vite-plugin-svelte": "^4.0.0",
+        "svelte": "^5.1.3",
         "vite": "^5.4.10"
       }
     },
     "node_modules/@ampproject/remapping": {
-      "version": "2.3.0: 
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz: 
-      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==: 
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
       "dev": true,
       "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5: 
+        "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.24"
       },
       "engines": {
@@ -27,9 +27,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.21.5: 
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz: 
-      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==: 
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
       "cpu": [
         "ppc64"
       ],
@@ -43,9 +43,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.21.5: 
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz: 
-      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==: 
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
       "cpu": [
         "arm"
       ],
@@ -59,9 +59,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.21.5: 
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz: 
-      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==: 
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
       "cpu": [
         "arm64"
       ],
@@ -75,9 +75,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.21.5: 
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz: 
-      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==: 
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
       "cpu": [
         "x64"
       ],
@@ -91,9 +91,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.21.5: 
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz: 
-      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==: 
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
       "cpu": [
         "arm64"
       ],
@@ -107,9 +107,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.21.5: 
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz: 
-      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==: 
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
       "cpu": [
         "x64"
       ],
@@ -123,9 +123,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.21.5: 
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz: 
-      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==: 
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
       "cpu": [
         "arm64"
       ],
@@ -139,9 +139,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.21.5: 
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz: 
-      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==: 
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
       "cpu": [
         "x64"
       ],
@@ -155,9 +155,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.21.5: 
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz: 
-      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==: 
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
       "cpu": [
         "arm"
       ],
@@ -171,9 +171,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.21.5: 
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz: 
-      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==: 
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
       "cpu": [
         "arm64"
       ],
@@ -187,9 +187,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.21.5: 
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz: 
-      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==: 
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
       "cpu": [
         "ia32"
       ],
@@ -203,9 +203,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.21.5: 
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz: 
-      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==: 
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
       "cpu": [
         "loong64"
       ],
@@ -219,9 +219,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.21.5: 
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz: 
-      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==: 
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
       "cpu": [
         "mips64el"
       ],
@@ -235,9 +235,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.21.5: 
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz: 
-      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==: 
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
       "cpu": [
         "ppc64"
       ],
@@ -251,9 +251,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.21.5: 
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz: 
-      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==: 
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
       "cpu": [
         "riscv64"
       ],
@@ -267,9 +267,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.21.5: 
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz: 
-      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==: 
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
       "cpu": [
         "s390x"
       ],
@@ -283,9 +283,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.21.5: 
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz: 
-      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==: 
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
       "cpu": [
         "x64"
       ],
@@ -299,9 +299,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.21.5: 
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz: 
-      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==: 
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
       "cpu": [
         "x64"
       ],
@@ -315,9 +315,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.21.5: 
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz: 
-      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==: 
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
       "cpu": [
         "x64"
       ],
@@ -331,9 +331,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.21.5: 
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz: 
-      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==: 
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
       "cpu": [
         "x64"
       ],
@@ -347,9 +347,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.21.5: 
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz: 
-      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==: 
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
       "cpu": [
         "arm64"
       ],
@@ -363,9 +363,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.21.5: 
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz: 
-      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==: 
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
       "cpu": [
         "ia32"
       ],
@@ -379,9 +379,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.21.5: 
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz: 
-      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==: 
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
       "cpu": [
         "x64"
       ],
@@ -395,13 +395,13 @@
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.5: 
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz: 
-      "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==: 
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
+      "integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
       "dev": true,
       "dependencies": {
-        "@jridgewell/set-array": "^1.2.1: 
-        "@jridgewell/sourcemap-codec": "^1.4.10: 
+        "@jridgewell/set-array": "^1.2.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
         "@jridgewell/trace-mapping": "^0.3.24"
       },
       "engines": {
@@ -409,43 +409,43 @@
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
-      "version": "3.1.2: 
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz: 
-      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==: 
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
       "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
     },
     "node_modules/@jridgewell/set-array": {
-      "version": "1.2.1: 
-      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz: 
-      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==: 
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
       "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.0: 
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz: 
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==: 
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
       "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.25: 
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz: 
-      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==: 
+      "version": "0.3.25",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
       "dev": true,
       "dependencies": {
-        "@jridgewell/resolve-uri": "^3.1.0: 
+        "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.27.3: 
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.27.3.tgz: 
-      "integrity": "sha512-EzxVSkIvCFxUd4Mgm4xR9YXrcp976qVaHnqom/Tgm+vU79k4vV4eYTjmRvGfeoW8m9LVcsAy/lGjcgVegKEhLQ==: 
+      "version": "4.34.9",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.34.9.tgz",
+      "integrity": "sha512-qZdlImWXur0CFakn2BJ2znJOdqYZKiedEPEVNTBrpfPjc/YuTGcaYZcdmNFTkUj3DU0ZM/AElcM8Ybww3xVLzA==",
       "cpu": [
         "arm"
       ],
@@ -456,9 +456,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.27.3: 
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.27.3.tgz: 
-      "integrity": "sha512-LJc5pDf1wjlt9o/Giaw9Ofl+k/vLUaYsE2zeQGH85giX2F+wn/Cg8b3c5CDP3qmVmeO5NzwVUzQQxwZvC2eQKw==: 
+      "version": "4.34.9",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.34.9.tgz",
+      "integrity": "sha512-4KW7P53h6HtJf5Y608T1ISKvNIYLWRKMvfnG0c44M6In4DQVU58HZFEVhWINDZKp7FZps98G3gxwC1sb0wXUUg==",
       "cpu": [
         "arm64"
       ],
@@ -469,9 +469,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.27.3: 
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.27.3.tgz: 
-      "integrity": "sha512-OuRysZ1Mt7wpWJ+aYKblVbJWtVn3Cy52h8nLuNSzTqSesYw1EuN6wKp5NW/4eSre3mp12gqFRXOKTcN3AI3LqA==: 
+      "version": "4.34.9",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.34.9.tgz",
+      "integrity": "sha512-0CY3/K54slrzLDjOA7TOjN1NuLKERBgk9nY5V34mhmuu673YNb+7ghaDUs6N0ujXR7fz5XaS5Aa6d2TNxZd0OQ==",
       "cpu": [
         "arm64"
       ],
@@ -482,9 +482,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.27.3: 
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.27.3.tgz: 
-      "integrity": "sha512-xW//zjJMlJs2sOrCmXdB4d0uiilZsOdlGQIC/jjmMWT47lkLLoB1nsNhPUcnoqyi5YR6I4h+FjBpILxbEy8JRg==: 
+      "version": "4.34.9",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.34.9.tgz",
+      "integrity": "sha512-eOojSEAi/acnsJVYRxnMkPFqcxSMFfrw7r2iD9Q32SGkb/Q9FpUY1UlAu1DH9T7j++gZ0lHjnm4OyH2vCI7l7Q==",
       "cpu": [
         "x64"
       ],
@@ -495,9 +495,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.27.3: 
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.27.3.tgz: 
-      "integrity": "sha512-58E0tIcwZ+12nK1WiLzHOD8I0d0kdrY/+o7yFVPRHuVGY3twBwzwDdTIBGRxLmyjciMYl1B/U515GJy+yn46qw==: 
+      "version": "4.34.9",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.34.9.tgz",
+      "integrity": "sha512-2lzjQPJbN5UnHm7bHIUKFMulGTQwdvOkouJDpPysJS+QFBGDJqcfh+CxxtG23Ik/9tEvnebQiylYoazFMAgrYw==",
       "cpu": [
         "arm64"
       ],
@@ -508,9 +508,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.27.3: 
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.27.3.tgz: 
-      "integrity": "sha512-78fohrpcVwTLxg1ZzBMlwEimoAJmY6B+5TsyAZ3Vok7YabRBUvjYTsRXPTjGEvv/mfgVBepbW28OlMEz4w8wGA==: 
+      "version": "4.34.9",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.34.9.tgz",
+      "integrity": "sha512-SLl0hi2Ah2H7xQYd6Qaiu01kFPzQ+hqvdYSoOtHYg/zCIFs6t8sV95kaoqjzjFwuYQLtOI0RZre/Ke0nPaQV+g==",
       "cpu": [
         "x64"
       ],
@@ -521,9 +521,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.27.3: 
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.27.3.tgz: 
-      "integrity": "sha512-h2Ay79YFXyQi+QZKo3ISZDyKaVD7uUvukEHTOft7kh00WF9mxAaxZsNs3o/eukbeKuH35jBvQqrT61fzKfAB/Q==: 
+      "version": "4.34.9",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.34.9.tgz",
+      "integrity": "sha512-88I+D3TeKItrw+Y/2ud4Tw0+3CxQ2kLgu3QvrogZ0OfkmX/DEppehus7L3TS2Q4lpB+hYyxhkQiYPJ6Mf5/dPg==",
       "cpu": [
         "arm"
       ],
@@ -534,9 +534,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.27.3: 
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.27.3.tgz: 
-      "integrity": "sha512-Sv2GWmrJfRY57urktVLQ0VKZjNZGogVtASAgosDZ1aUB+ykPxSi3X1nWORL5Jk0sTIIwQiPH7iE3BMi9zGWfkg==: 
+      "version": "4.34.9",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.34.9.tgz",
+      "integrity": "sha512-3qyfWljSFHi9zH0KgtEPG4cBXHDFhwD8kwg6xLfHQ0IWuH9crp005GfoUUh/6w9/FWGBwEHg3lxK1iHRN1MFlA==",
       "cpu": [
         "arm"
       ],
@@ -547,9 +547,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.27.3: 
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.27.3.tgz: 
-      "integrity": "sha512-FPoJBLsPW2bDNWjSrwNuTPUt30VnfM8GPGRoLCYKZpPx0xiIEdFip3dH6CqgoT0RnoGXptaNziM0WlKgBc+OWQ==: 
+      "version": "4.34.9",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.34.9.tgz",
+      "integrity": "sha512-6TZjPHjKZUQKmVKMUowF3ewHxctrRR09eYyvT5eFv8w/fXarEra83A2mHTVJLA5xU91aCNOUnM+DWFMSbQ0Nxw==",
       "cpu": [
         "arm64"
       ],
@@ -560,9 +560,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.27.3: 
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.27.3.tgz: 
-      "integrity": "sha512-TKxiOvBorYq4sUpA0JT+Fkh+l+G9DScnG5Dqx7wiiqVMiRSkzTclP35pE6eQQYjP4Gc8yEkJGea6rz4qyWhp3g==: 
+      "version": "4.34.9",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.34.9.tgz",
+      "integrity": "sha512-LD2fytxZJZ6xzOKnMbIpgzFOuIKlxVOpiMAXawsAZ2mHBPEYOnLRK5TTEsID6z4eM23DuO88X0Tq1mErHMVq0A==",
       "cpu": [
         "arm64"
       ],
@@ -572,10 +572,23 @@
         "linux"
       ]
     },
+    "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
+      "version": "4.34.9",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.34.9.tgz",
+      "integrity": "sha512-dRAgTfDsn0TE0HI6cmo13hemKpVHOEyeciGtvlBTkpx/F65kTvShtY/EVyZEIfxFkV5JJTuQ9tP5HGBS0hfxIg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
     "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.27.3: 
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.27.3.tgz: 
-      "integrity": "sha512-v2M/mPvVUKVOKITa0oCFksnQQ/TqGrT+yD0184/cWHIu0LoIuYHwox0Pm3ccXEz8cEQDLk6FPKd1CCm+PlsISw==: 
+      "version": "4.34.9",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.34.9.tgz",
+      "integrity": "sha512-PHcNOAEhkoMSQtMf+rJofwisZqaU8iQ8EaSps58f5HYll9EAY5BSErCZ8qBDMVbq88h4UxaNPlbrKqfWP8RfJA==",
       "cpu": [
         "ppc64"
       ],
@@ -586,9 +599,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.27.3: 
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.27.3.tgz: 
-      "integrity": "sha512-LdrI4Yocb1a/tFVkzmOE5WyYRgEBOyEhWYJe4gsDWDiwnjYKjNs7PS6SGlTDB7maOHF4kxevsuNBl2iOcj3b4A==: 
+      "version": "4.34.9",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.34.9.tgz",
+      "integrity": "sha512-Z2i0Uy5G96KBYKjeQFKbbsB54xFOL5/y1P5wNBsbXB8yE+At3oh0DVMjQVzCJRJSfReiB2tX8T6HUFZ2k8iaKg==",
       "cpu": [
         "riscv64"
       ],
@@ -599,9 +612,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.27.3: 
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.27.3.tgz: 
-      "integrity": "sha512-d4wVu6SXij/jyiwPvI6C4KxdGzuZOvJ6y9VfrcleHTwo68fl8vZC5ZYHsCVPUi4tndCfMlFniWgwonQ5CUpQcA==: 
+      "version": "4.34.9",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.34.9.tgz",
+      "integrity": "sha512-U+5SwTMoeYXoDzJX5dhDTxRltSrIax8KWwfaaYcynuJw8mT33W7oOgz0a+AaXtGuvhzTr2tVKh5UO8GVANTxyQ==",
       "cpu": [
         "s390x"
       ],
@@ -612,9 +625,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.27.3: 
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.27.3.tgz: 
-      "integrity": "sha512-/6bn6pp1fsCGEY5n3yajmzZQAh+mW4QPItbiWxs69zskBzJuheb3tNynEjL+mKOsUSFK11X4LYF2BwwXnzWleA==: 
+      "version": "4.34.9",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.34.9.tgz",
+      "integrity": "sha512-FwBHNSOjUTQLP4MG7y6rR6qbGw4MFeQnIBrMe161QGaQoBQLqSUEKlHIiVgF3g/mb3lxlxzJOpIBhaP+C+KP2A==",
       "cpu": [
         "x64"
       ],
@@ -625,9 +638,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.27.3: 
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.27.3.tgz: 
-      "integrity": "sha512-nBXOfJds8OzUT1qUreT/en3eyOXd2EH5b0wr2bVB5999qHdGKkzGzIyKYaKj02lXk6wpN71ltLIaQpu58YFBoQ==: 
+      "version": "4.34.9",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.34.9.tgz",
+      "integrity": "sha512-cYRpV4650z2I3/s6+5/LONkjIz8MBeqrk+vPXV10ORBnshpn8S32bPqQ2Utv39jCiDcO2eJTuSlPXpnvmaIgRA==",
       "cpu": [
         "x64"
       ],
@@ -638,9 +651,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.27.3: 
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.27.3.tgz: 
-      "integrity": "sha512-ogfbEVQgIZOz5WPWXF2HVb6En+kWzScuxJo/WdQTqEgeyGkaa2ui5sQav9Zkr7bnNCLK48uxmmK0TySm22eiuw==: 
+      "version": "4.34.9",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.34.9.tgz",
+      "integrity": "sha512-z4mQK9dAN6byRA/vsSgQiPeuO63wdiDxZ9yg9iyX2QTzKuQM7T4xlBoeUP/J8uiFkqxkcWndWi+W7bXdPbt27Q==",
       "cpu": [
         "arm64"
       ],
@@ -651,9 +664,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.27.3: 
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.27.3.tgz: 
-      "integrity": "sha512-ecE36ZBMLINqiTtSNQ1vzWc5pXLQHlf/oqGp/bSbi7iedcjcNb6QbCBNG73Euyy2C+l/fn8qKWEwxr+0SSfs3w==: 
+      "version": "4.34.9",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.34.9.tgz",
+      "integrity": "sha512-KB48mPtaoHy1AwDNkAJfHXvHp24H0ryZog28spEs0V48l3H1fr4i37tiyHsgKZJnCmvxsbATdZGBpbmxTE3a9w==",
       "cpu": [
         "ia32"
       ],
@@ -664,9 +677,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.27.3: 
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.27.3.tgz: 
-      "integrity": "sha512-vliZLrDmYKyaUoMzEbMTg2JkerfBjn03KmAw9CykO0Zzkzoyd7o3iZNam/TpyWNjNT+Cz2iO3P9Smv2wgrR+Eg==: 
+      "version": "4.34.9",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.34.9.tgz",
+      "integrity": "sha512-AyleYRPU7+rgkMWbEh71fQlrzRfeP6SyMnRf9XX4fCdDPAJumdSBqYEcWPMzVQ4ScAl7E4oFfK0GUVn77xSwbw==",
       "cpu": [
         "x64"
       ],
@@ -677,30 +690,30 @@
       ]
     },
     "node_modules/@sveltejs/vite-plugin-svelte": {
-      "version": "4.0.1: 
-      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-4.0.1.tgz: 
-      "integrity": "sha512-prXoAE/GleD2C4pKgHa9vkdjpzdYwCSw/kmjw6adIyu0vk5YKCfqIztkLg10m+kOYnzZu3bb0NaPTxlWre2a9Q==: 
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-4.0.4.tgz",
+      "integrity": "sha512-0ba1RQ/PHen5FGpdSrW7Y3fAMQjrXantECALeOiOdBdzR5+5vPP6HVZRLmZaQL+W8m++o+haIAKq5qT+MiZ7VA==",
       "dev": true,
       "dependencies": {
-        "@sveltejs/vite-plugin-svelte-inspector": "^3.0.0-next.0||^3.0.0: 
-        "debug": "^4.3.7: 
-        "deepmerge": "^4.3.1: 
-        "kleur": "^4.1.5: 
-        "magic-string": "^0.30.12: 
+        "@sveltejs/vite-plugin-svelte-inspector": "^3.0.0-next.0||^3.0.0",
+        "debug": "^4.3.7",
+        "deepmerge": "^4.3.1",
+        "kleur": "^4.1.5",
+        "magic-string": "^0.30.12",
         "vitefu": "^1.0.3"
       },
       "engines": {
         "node": "^18.0.0 || ^20.0.0 || >=22"
       },
       "peerDependencies": {
-        "svelte": "^5.0.0-next.96 || ^5.0.0: 
+        "svelte": "^5.0.0-next.96 || ^5.0.0",
         "vite": "^5.0.0"
       }
     },
     "node_modules/@sveltejs/vite-plugin-svelte-inspector": {
-      "version": "3.0.1: 
-      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte-inspector/-/vite-plugin-svelte-inspector-3.0.1.tgz: 
-      "integrity": "sha512-2CKypmj1sM4GE7HjllT7UKmo4Q6L5xFRd7VMGEWhYnZ+wc6AUVU01IBd7yUi6WnFndEwWoMNOd6e8UjoN0nbvQ==: 
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte-inspector/-/vite-plugin-svelte-inspector-3.0.1.tgz",
+      "integrity": "sha512-2CKypmj1sM4GE7HjllT7UKmo4Q6L5xFRd7VMGEWhYnZ+wc6AUVU01IBd7yUi6WnFndEwWoMNOd6e8UjoN0nbvQ==",
       "dev": true,
       "dependencies": {
         "debug": "^4.3.7"
@@ -709,21 +722,21 @@
         "node": "^18.0.0 || ^20.0.0 || >=22"
       },
       "peerDependencies": {
-        "@sveltejs/vite-plugin-svelte": "^4.0.0-next.0||^4.0.0: 
-        "svelte": "^5.0.0-next.96 || ^5.0.0: 
+        "@sveltejs/vite-plugin-svelte": "^4.0.0-next.0||^4.0.0",
+        "svelte": "^5.0.0-next.96 || ^5.0.0",
         "vite": "^5.0.0"
       }
     },
     "node_modules/@types/estree": {
-      "version": "1.0.6: 
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz: 
-      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==: 
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
       "dev": true
     },
     "node_modules/acorn": {
-      "version": "8.14.0: 
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz: 
-      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==: 
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -733,36 +746,45 @@
       }
     },
     "node_modules/acorn-typescript": {
-      "version": "1.4.13: 
-      "resolved": "https://registry.npmjs.org/acorn-typescript/-/acorn-typescript-1.4.13.tgz: 
-      "integrity": "sha512-xsc9Xv0xlVfwp2o7sQ+GCQ1PgbkdcpWdTzrwXxO3xDMTAywVS3oXVOcOHuRjAPkS4P9b+yc/qNF15460v+jp4Q==: 
+      "version": "1.4.13",
+      "resolved": "https://registry.npmjs.org/acorn-typescript/-/acorn-typescript-1.4.13.tgz",
+      "integrity": "sha512-xsc9Xv0xlVfwp2o7sQ+GCQ1PgbkdcpWdTzrwXxO3xDMTAywVS3oXVOcOHuRjAPkS4P9b+yc/qNF15460v+jp4Q==",
       "dev": true,
       "peerDependencies": {
         "acorn": ">=8.9.0"
       }
     },
     "node_modules/aria-query": {
-      "version": "5.3.2: 
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz: 
-      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==: 
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
       "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/axobject-query": {
-      "version": "4.1.0: 
-      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz: 
-      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==: 
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
       "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/debug": {
-      "version": "4.3.7: 
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz: 
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==: 
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
       "dev": true,
       "dependencies": {
         "ms": "^2.1.3"
@@ -777,18 +799,18 @@
       }
     },
     "node_modules/deepmerge": {
-      "version": "4.3.1: 
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz: 
-      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==: 
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/esbuild": {
-      "version": "0.21.5: 
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz: 
-      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==: 
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -798,51 +820,50 @@
         "node": ">=12"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.21.5: 
-        "@esbuild/android-arm": "0.21.5: 
-        "@esbuild/android-arm64": "0.21.5: 
-        "@esbuild/android-x64": "0.21.5: 
-        "@esbuild/darwin-arm64": "0.21.5: 
-        "@esbuild/darwin-x64": "0.21.5: 
-        "@esbuild/freebsd-arm64": "0.21.5: 
-        "@esbuild/freebsd-x64": "0.21.5: 
-        "@esbuild/linux-arm": "0.21.5: 
-        "@esbuild/linux-arm64": "0.21.5: 
-        "@esbuild/linux-ia32": "0.21.5: 
-        "@esbuild/linux-loong64": "0.21.5: 
-        "@esbuild/linux-mips64el": "0.21.5: 
-        "@esbuild/linux-ppc64": "0.21.5: 
-        "@esbuild/linux-riscv64": "0.21.5: 
-        "@esbuild/linux-s390x": "0.21.5: 
-        "@esbuild/linux-x64": "0.21.5: 
-        "@esbuild/netbsd-x64": "0.21.5: 
-        "@esbuild/openbsd-x64": "0.21.5: 
-        "@esbuild/sunos-x64": "0.21.5: 
-        "@esbuild/win32-arm64": "0.21.5: 
-        "@esbuild/win32-ia32": "0.21.5: 
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
         "@esbuild/win32-x64": "0.21.5"
       }
     },
     "node_modules/esm-env": {
-      "version": "1.1.4: 
-      "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.1.4.tgz: 
-      "integrity": "sha512-oO82nKPHKkzIj/hbtuDYy/JHqBHFlMIW36SDiPCVsj87ntDLcWN+sJ1erdVryd4NxODacFTsdrIE3b7IamqbOg==: 
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
+      "integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
       "dev": true
     },
     "node_modules/esrap": {
-      "version": "1.2.2: 
-      "resolved": "https://registry.npmjs.org/esrap/-/esrap-1.2.2.tgz: 
-      "integrity": "sha512-F2pSJklxx1BlQIQgooczXCPHmcWpn6EsP5oo73LQfonG9fIlIENQ8vMmfGXeojP9MrkzUNAfyU5vdFlR9shHAw==: 
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/esrap/-/esrap-1.4.5.tgz",
+      "integrity": "sha512-CjNMjkBWWZeHn+VX+gS8YvFwJ5+NDhg8aWZBSFJPR8qQduDNjbJodA2WcwCm7uQa5Rjqj+nZvVmceg1RbHFB9g==",
       "dev": true,
       "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.4.15: 
-        "@types/estree": "^1.0.1"
+        "@jridgewell/sourcemap-codec": "^1.4.15"
       }
     },
     "node_modules/fsevents": {
-      "version": "2.3.3: 
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz: 
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==: 
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
       "hasInstallScript": true,
       "optional": true,
@@ -854,52 +875,52 @@
       }
     },
     "node_modules/is-reference": {
-      "version": "3.0.3: 
-      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz: 
-      "integrity": "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==: 
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
+      "integrity": "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==",
       "dev": true,
       "dependencies": {
         "@types/estree": "^1.0.6"
       }
     },
     "node_modules/kleur": {
-      "version": "4.1.5: 
-      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz: 
-      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==: 
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
       "dev": true,
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/locate-character": {
-      "version": "3.0.0: 
-      "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz: 
-      "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==: 
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
+      "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
       "dev": true
     },
     "node_modules/magic-string": {
-      "version": "0.30.13: 
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.13.tgz: 
-      "integrity": "sha512-8rYBO+MsWkgjDSOvLomYnzhdwEG51olQ4zL5KXnNJWV5MNmrb4rTZdrtkhxjnD/QyZUqR/Z/XDsUs/4ej2nx0g==: 
+      "version": "0.30.17",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
+      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
       "dev": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0"
       }
     },
     "node_modules/ms": {
-      "version": "2.1.3: 
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz: 
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==: 
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.7: 
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz: 
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==: 
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
       "dev": true,
       "funding": [
         {
-          "type": "github: 
+          "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
       ],
@@ -911,33 +932,33 @@
       }
     },
     "node_modules/picocolors": {
-      "version": "1.1.1: 
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz: 
-      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==: 
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true
     },
     "node_modules/postcss": {
-      "version": "8.4.49: 
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz: 
-      "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==: 
+      "version": "8.5.3",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
+      "integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
       "dev": true,
       "funding": [
         {
-          "type": "opencollective: 
+          "type": "opencollective",
           "url": "https://opencollective.com/postcss/"
         },
         {
-          "type": "tidelift: 
+          "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/postcss"
         },
         {
-          "type": "github: 
+          "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
       ],
       "dependencies": {
-        "nanoid": "^3.3.7: 
-        "picocolors": "^1.1.1: 
+        "nanoid": "^3.3.8",
+        "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
       "engines": {
@@ -945,9 +966,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.27.3: 
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.27.3.tgz: 
-      "integrity": "sha512-SLsCOnlmGt9VoZ9Ek8yBK8tAdmPHeppkw+Xa7yDlCEhDTvwYei03JlWo1fdc7YTfLZ4tD8riJCUyAgTbszk1fQ==: 
+      "version": "4.34.9",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.34.9.tgz",
+      "integrity": "sha512-nF5XYqWWp9hx/LrpC8sZvvvmq0TeTjQgaZHYmAgwysT9nh8sWnZhBnM8ZyVbbJFIQBLwHDNoMqsBZBbUo4U8sQ==",
       "dev": true,
       "dependencies": {
         "@types/estree": "1.0.6"
@@ -956,58 +977,60 @@
         "rollup": "dist/bin/rollup"
       },
       "engines": {
-        "node": ">=18.0.0: 
+        "node": ">=18.0.0",
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.27.3: 
-        "@rollup/rollup-android-arm64": "4.27.3: 
-        "@rollup/rollup-darwin-arm64": "4.27.3: 
-        "@rollup/rollup-darwin-x64": "4.27.3: 
-        "@rollup/rollup-freebsd-arm64": "4.27.3: 
-        "@rollup/rollup-freebsd-x64": "4.27.3: 
-        "@rollup/rollup-linux-arm-gnueabihf": "4.27.3: 
-        "@rollup/rollup-linux-arm-musleabihf": "4.27.3: 
-        "@rollup/rollup-linux-arm64-gnu": "4.27.3: 
-        "@rollup/rollup-linux-arm64-musl": "4.27.3: 
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.27.3: 
-        "@rollup/rollup-linux-riscv64-gnu": "4.27.3: 
-        "@rollup/rollup-linux-s390x-gnu": "4.27.3: 
-        "@rollup/rollup-linux-x64-gnu": "4.27.3: 
-        "@rollup/rollup-linux-x64-musl": "4.27.3: 
-        "@rollup/rollup-win32-arm64-msvc": "4.27.3: 
-        "@rollup/rollup-win32-ia32-msvc": "4.27.3: 
-        "@rollup/rollup-win32-x64-msvc": "4.27.3: 
+        "@rollup/rollup-android-arm-eabi": "4.34.9",
+        "@rollup/rollup-android-arm64": "4.34.9",
+        "@rollup/rollup-darwin-arm64": "4.34.9",
+        "@rollup/rollup-darwin-x64": "4.34.9",
+        "@rollup/rollup-freebsd-arm64": "4.34.9",
+        "@rollup/rollup-freebsd-x64": "4.34.9",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.34.9",
+        "@rollup/rollup-linux-arm-musleabihf": "4.34.9",
+        "@rollup/rollup-linux-arm64-gnu": "4.34.9",
+        "@rollup/rollup-linux-arm64-musl": "4.34.9",
+        "@rollup/rollup-linux-loongarch64-gnu": "4.34.9",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.34.9",
+        "@rollup/rollup-linux-riscv64-gnu": "4.34.9",
+        "@rollup/rollup-linux-s390x-gnu": "4.34.9",
+        "@rollup/rollup-linux-x64-gnu": "4.34.9",
+        "@rollup/rollup-linux-x64-musl": "4.34.9",
+        "@rollup/rollup-win32-arm64-msvc": "4.34.9",
+        "@rollup/rollup-win32-ia32-msvc": "4.34.9",
+        "@rollup/rollup-win32-x64-msvc": "4.34.9",
         "fsevents": "~2.3.2"
       }
     },
     "node_modules/source-map-js": {
-      "version": "1.2.1: 
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz: 
-      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==: 
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/svelte": {
-      "version": "5.2.7: 
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.2.7.tgz: 
-      "integrity": "sha512-cEhPGuLHiH2+Z8B1FwQgiZJgA39uUmJR4516TKrM5zrp0/cuwJkfhUfcTxhAkznanAF5fXUKzvYR4o+Ksx3ZCQ==: 
+      "version": "5.20.5",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.20.5.tgz",
+      "integrity": "sha512-dpu2lTPVsAAgZFKpF7A9741sBCdXGogfxFU4aQeVgun7GVNCSVheTzj0FsT7g9OsLhBaMX4lKLwVIvmzQGytmQ==",
       "dev": true,
       "dependencies": {
-        "@ampproject/remapping": "^2.3.0: 
-        "@jridgewell/sourcemap-codec": "^1.5.0: 
-        "@types/estree": "^1.0.5: 
-        "acorn": "^8.12.1: 
-        "acorn-typescript": "^1.4.13: 
-        "aria-query": "^5.3.1: 
-        "axobject-query": "^4.1.0: 
-        "esm-env": "^1.0.0: 
-        "esrap": "^1.2.2: 
-        "is-reference": "^3.0.3: 
-        "locate-character": "^3.0.0: 
-        "magic-string": "^0.30.11: 
+        "@ampproject/remapping": "^2.3.0",
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@types/estree": "^1.0.5",
+        "acorn": "^8.12.1",
+        "acorn-typescript": "^1.4.13",
+        "aria-query": "^5.3.1",
+        "axobject-query": "^4.1.0",
+        "clsx": "^2.1.1",
+        "esm-env": "^1.2.1",
+        "esrap": "^1.4.3",
+        "is-reference": "^3.0.3",
+        "locate-character": "^3.0.0",
+        "magic-string": "^0.30.11",
         "zimmerframe": "^1.1.2"
       },
       "engines": {
@@ -1015,13 +1038,13 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.4.11: 
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.11.tgz: 
-      "integrity": "sha512-c7jFQRklXua0mTzneGW9QVyxFjUgwcihC4bXEtujIo2ouWCe1Ajt/amn2PCxYnhYfd5k09JX3SB7OYWFKYqj8Q==: 
+      "version": "5.4.14",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.14.tgz",
+      "integrity": "sha512-EK5cY7Q1D8JNhSaPKVK4pwBFvaTmZxEnoKXLG/U9gmdDcihQGNzFlgIvaxezFR4glP1LsuiedwMBqCXH3wZccA==",
       "dev": true,
       "dependencies": {
-        "esbuild": "^0.21.3: 
-        "postcss": "^8.4.43: 
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
         "rollup": "^4.20.0"
       },
       "bin": {
@@ -1037,13 +1060,13 @@
         "fsevents": "~2.3.3"
       },
       "peerDependencies": {
-        "@types/node": "^18.0.0 || >=20.0.0: 
-        "less": "*: 
-        "lightningcss": "^1.21.0: 
-        "sass": "*: 
-        "sass-embedded": "*: 
-        "stylus": "*: 
-        "sugarss": "*: 
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
         "terser": "^5.4.0"
       },
       "peerDependenciesMeta": {
@@ -1074,12 +1097,12 @@
       }
     },
     "node_modules/vitefu": {
-      "version": "1.0.3: 
-      "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.0.3.tgz: 
-      "integrity": "sha512-iKKfOMBHob2WxEJbqbJjHAkmYgvFDPhuqrO82om83S8RLk+17FtyMBfcyeH8GqD0ihShtkMW/zzJgiA51hCNCQ==: 
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.0.6.tgz",
+      "integrity": "sha512-+Rex1GlappUyNN6UfwbVZne/9cYC4+R2XDk9xkNXBKMw6HQagdX9PgZ8V2v1WUSK1wfBLp7qbI1+XSNIlB1xmA==",
       "dev": true,
       "peerDependencies": {
-        "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0-beta.0"
+        "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0"
       },
       "peerDependenciesMeta": {
         "vite": {
@@ -1088,9 +1111,9 @@
       }
     },
     "node_modules/zimmerframe": {
-      "version": "1.1.2: 
-      "resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.2.tgz: 
-      "integrity": "sha512-rAbqEGa8ovJy4pyBxZM70hg4pE6gDgaQ0Sl9M3enG3I0d6H4XSAM3GeNGLKnsBpuijUow064sf7ww1nutC5/3w==: 
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.2.tgz",
+      "integrity": "sha512-rAbqEGa8ovJy4pyBxZM70hg4pE6gDgaQ0Sl9M3enG3I0d6H4XSAM3GeNGLKnsBpuijUow064sf7ww1nutC5/3w==",
       "dev": true
     }
   }

--- a/src/Viz.svelte
+++ b/src/Viz.svelte
@@ -1,12 +1,18 @@
 <script>
-  let { radius, stroke, color } = $props()
+  let { radius, stroke, color } = $props();
 
   let width = $state(500); // Default values
   let height = $state(500);
 </script>
 
 <svelte:window bind:innerWidth={width} bind:innerHeight={height} />
-
 <svg {width} {height}>
-  <circle cx={width / 2} cy={height / 2} r={radius} fill={color} stroke="black" stroke-width={stroke}></circle>
+  <circle
+    cx={width / 2}
+    cy={height / 2}
+    r={radius}
+    fill={color}
+    stroke="black"
+    stroke-width={stroke}
+  ></circle>
 </svg>

--- a/src/template.svelte.js
+++ b/src/template.svelte.js
@@ -2,35 +2,35 @@ import { mount } from 'svelte';
 import Viz from './Viz.svelte';
 
 export var data = {};
-// If your template includes data tables, use this variable to access the data.
-// Each of the 'datasets' in data.json file will be available as properties of the data.
 
-class vizState {
-  radius = $state()
-  stroke = $state()
-  color = $state()
+// Set up state as a serializable object
+export var state = {
+  radius: 50,
+  stroke: 2,
+  color: '#ffffff',
+};
 
-  constructor(radius, stroke, color) {
-    this.radius = radius;
-    this.stroke = stroke;
-    this.color = color;
-  }
-}
-
-export var state = new vizState(10, 1, "#FF0000")
+// Create a separate reactive store for internal Svelte use
+let reactiveState = $state({ ...state });
 
 // The draw function is called when the template first loads
 export function draw() {
-    mount(Viz, {
-      target: document.body,
-      props: state
-    })
+  reactiveState.data = data;
+
+  mount(Viz, {
+    target: document.body,
+    props: reactiveState, // Pass the reactive state to Svelte
+  });
 }
 
-  // The update function is called whenever the user changes a data table or settings
-  // in the visualisation editor, or when changing slides in the story editor.
-  // Tip: to make your template work nicely in the story editor, ensure that all user
-  // interface controls such as buttons and sliders update the state and then call update.
+// The update function is called whenever the user changes a data table or settings
+// in the visualisation editor, or when changing slides in the story editor.
+// Tip: to make your template work nicely in the story editor, ensure that all user
+// interface controls such as buttons and sliders update the state and then call update.
 export function update() {
-	if (state.radius <= 0) throw new Error("Radius must be positive");
+  if (state.radius <= 0) throw new Error('Radius must be positive');
+
+  // Update reactive state with changes from Flourish
+  Object.assign(reactiveState, state);
+  reactiveState.data = data;
 }

--- a/src/template.svelte.js
+++ b/src/template.svelte.js
@@ -11,10 +11,11 @@ export var state = {
 };
 
 // Create a separate reactive store for internal Svelte use
-let reactiveState = $state({ ...state });
+let reactiveState = $state({});
 
 // The draw function is called when the template first loads
 export function draw() {
+  reactiveState = { ...state };
   reactiveState.data = data;
 
   mount(Viz, {

--- a/style.css
+++ b/style.css
@@ -1,0 +1,1 @@
+svg.svelte-ieg5x{display:block}

--- a/template.js
+++ b/template.js
@@ -3,30 +3,21 @@ var template = function(exports) {
   const UNINITIALIZED = Symbol();
   const FILENAME = Symbol("filename");
   const DEV = true;
-  const DERIVED = 1 << 1;
-  const EFFECT = 1 << 2;
-  const RENDER_EFFECT = 1 << 3;
-  const BLOCK_EFFECT = 1 << 4;
-  const BRANCH_EFFECT = 1 << 5;
-  const ROOT_EFFECT = 1 << 6;
-  const BOUNDARY_EFFECT = 1 << 7;
-  const UNOWNED = 1 << 8;
-  const DISCONNECTED = 1 << 9;
-  const CLEAN = 1 << 10;
-  const DIRTY = 1 << 11;
-  const MAYBE_DIRTY = 1 << 12;
-  const INERT = 1 << 13;
-  const DESTROYED = 1 << 14;
-  const EFFECT_RAN = 1 << 15;
-  const EFFECT_TRANSPARENT = 1 << 16;
-  const INSPECT_EFFECT = 1 << 18;
-  const HEAD_EFFECT = 1 << 19;
-  const EFFECT_HAS_DERIVED = 1 << 20;
-  const STATE_SYMBOL = Symbol("$state");
-  const STATE_SYMBOL_METADATA = Symbol("$state metadata");
-  const LOADING_ATTR_SYMBOL = Symbol("");
+  var bold = "font-weight: bold";
+  var normal = "font-weight: normal";
+  function ownership_invalid_mutation(component, owner) {
+    {
+      console.warn(`%c[svelte] ownership_invalid_mutation
+%c${component ? `${component} mutated a value owned by ${owner}. This is strongly discouraged. Consider passing values to child components with \`bind:\`, or use a callback instead` : "Mutating a value outside the component that created it is strongly discouraged. Consider passing values to child components with `bind:`, or use a callback instead"}`, bold, normal);
+    }
+  }
+  function state_proxy_equality_mismatch(operator) {
+    {
+      console.warn(`%c[svelte] state_proxy_equality_mismatch
+%cReactive \`$state(...)\` proxies and the values they proxy have different identities. Because of this, comparisons with \`${operator}\` will produce unexpected results`, bold, normal);
+    }
+  }
   var is_array = Array.isArray;
-  var index_of = Array.prototype.indexOf;
   var array_from = Array.from;
   var define_property = Object.defineProperty;
   var get_descriptor = Object.getOwnPropertyDescriptor;
@@ -34,14 +25,49 @@ var template = function(exports) {
   var object_prototype = Object.prototype;
   var array_prototype = Array.prototype;
   var get_prototype_of = Object.getPrototypeOf;
+  const DERIVED = 1 << 1;
+  const EFFECT = 1 << 2;
+  const RENDER_EFFECT = 1 << 3;
+  const BLOCK_EFFECT = 1 << 4;
+  const BRANCH_EFFECT = 1 << 5;
+  const ROOT_EFFECT = 1 << 6;
+  const UNOWNED = 1 << 7;
+  const DISCONNECTED = 1 << 8;
+  const CLEAN = 1 << 9;
+  const DIRTY = 1 << 10;
+  const MAYBE_DIRTY = 1 << 11;
+  const INERT = 1 << 12;
+  const DESTROYED = 1 << 13;
+  const EFFECT_RAN = 1 << 14;
+  const INSPECT_EFFECT = 1 << 17;
+  const HEAD_EFFECT = 1 << 18;
+  const EFFECT_HAS_DERIVED = 1 << 19;
+  const STATE_SYMBOL = Symbol("$state");
+  const STATE_SYMBOL_METADATA = Symbol("$state metadata");
+  const LOADING_ATTR_SYMBOL = Symbol("");
   function equals(value) {
     return value === this.v;
+  }
+  function bind_invalid_export(component, key, name) {
+    {
+      const error = new Error(`bind_invalid_export
+Component ${component} has an export named \`${key}\` that a consumer component is trying to access using \`bind:${key}\`, which is disallowed. Instead, use \`bind:this\` (e.g. \`<${name} bind:this={component} />\`) and then access the property on the bound component instance (e.g. \`component.${key}\`)`);
+      error.name = "Svelte error";
+      throw error;
+    }
+  }
+  function bind_not_bindable(key, component, name) {
+    {
+      const error = new Error(`bind_not_bindable
+A component is attempting to bind to a non-bindable property \`${key}\` belonging to ${component} (i.e. \`<${name} bind:${key}={...}>\`). To mark a property as bindable: \`let { ${key} = $bindable() } = $props()\``);
+      error.name = "Svelte error";
+      throw error;
+    }
   }
   function component_api_changed(parent, method, component) {
     {
       const error = new Error(`component_api_changed
-${parent} called \`${method}\` on an instance of ${component}, which is no longer valid in Svelte 5
-https://svelte.dev/e/component_api_changed`);
+${parent} called \`${method}\` on an instance of ${component}, which is no longer valid in Svelte 5. See https://svelte.dev/docs/svelte/v5-migration-guide#Components-are-no-longer-classes for more information`);
       error.name = "Svelte error";
       throw error;
     }
@@ -49,8 +75,7 @@ https://svelte.dev/e/component_api_changed`);
   function component_api_invalid_new(component, name) {
     {
       const error = new Error(`component_api_invalid_new
-Attempted to instantiate ${component} with \`new ${name}\`, which is no longer valid in Svelte 5. If this component is not under your control, set the \`compatibility.componentApi\` compiler option to \`4\` to keep it working.
-https://svelte.dev/e/component_api_invalid_new`);
+Attempted to instantiate ${component} with \`new ${name}\`, which is no longer valid in Svelte 5. If this component is not under your control, set the \`compatibility.componentApi\` compiler option to \`4\` to keep it working. See https://svelte.dev/docs/svelte/v5-migration-guide#Components-are-no-longer-classes for more information`);
       error.name = "Svelte error";
       throw error;
     }
@@ -58,8 +83,7 @@ https://svelte.dev/e/component_api_invalid_new`);
   function derived_references_self() {
     {
       const error = new Error(`derived_references_self
-A derived value cannot reference itself recursively
-https://svelte.dev/e/derived_references_self`);
+A derived value cannot reference itself recursively`);
       error.name = "Svelte error";
       throw error;
     }
@@ -67,8 +91,7 @@ https://svelte.dev/e/derived_references_self`);
   function effect_update_depth_exceeded() {
     {
       const error = new Error(`effect_update_depth_exceeded
-Maximum update depth exceeded. This can happen when a reactive block or effect repeatedly sets a new value. Svelte limits the number of nested updates to prevent infinite loops
-https://svelte.dev/e/effect_update_depth_exceeded`);
+Maximum update depth exceeded. This can happen when a reactive block or effect repeatedly sets a new value. Svelte limits the number of nested updates to prevent infinite loops`);
       error.name = "Svelte error";
       throw error;
     }
@@ -76,8 +99,7 @@ https://svelte.dev/e/effect_update_depth_exceeded`);
   function rune_outside_svelte(rune) {
     {
       const error = new Error(`rune_outside_svelte
-The \`${rune}\` rune is only available inside \`.svelte\` and \`.svelte.js/ts\` files
-https://svelte.dev/e/rune_outside_svelte`);
+The \`${rune}\` rune is only available inside \`.svelte\` and \`.svelte.js/ts\` files`);
       error.name = "Svelte error";
       throw error;
     }
@@ -85,8 +107,7 @@ https://svelte.dev/e/rune_outside_svelte`);
   function state_descriptors_fixed() {
     {
       const error = new Error(`state_descriptors_fixed
-Property descriptors defined on \`$state\` objects must contain \`value\` and always be \`enumerable\`, \`configurable\` and \`writable\`.
-https://svelte.dev/e/state_descriptors_fixed`);
+Property descriptors defined on \`$state\` objects must contain \`value\` and always be \`enumerable\`, \`configurable\` and \`writable\`.`);
       error.name = "Svelte error";
       throw error;
     }
@@ -94,8 +115,7 @@ https://svelte.dev/e/state_descriptors_fixed`);
   function state_prototype_fixed() {
     {
       const error = new Error(`state_prototype_fixed
-Cannot set prototype of \`$state\` object
-https://svelte.dev/e/state_prototype_fixed`);
+Cannot set prototype of \`$state\` object`);
       error.name = "Svelte error";
       throw error;
     }
@@ -103,8 +123,7 @@ https://svelte.dev/e/state_prototype_fixed`);
   function state_unsafe_local_read() {
     {
       const error = new Error(`state_unsafe_local_read
-Reading state that was created inside the same derived is forbidden. Consider using \`untrack\` to read locally created state
-https://svelte.dev/e/state_unsafe_local_read`);
+Reading state that was created inside the same derived is forbidden. Consider using \`untrack\` to read locally created state`);
       error.name = "Svelte error";
       throw error;
     }
@@ -112,35 +131,32 @@ https://svelte.dev/e/state_unsafe_local_read`);
   function state_unsafe_mutation() {
     {
       const error = new Error(`state_unsafe_mutation
-Updating state inside a derived or a template expression is forbidden. If the value should not be reactive, declare it without \`$state\`
-https://svelte.dev/e/state_unsafe_mutation`);
+Updating state inside a derived or a template expression is forbidden. If the value should not be reactive, declare it without \`$state\``);
       error.name = "Svelte error";
       throw error;
     }
   }
-  let tracing_mode_flag = false;
+  let legacy_mode_flag = false;
   let inspect_effects = /* @__PURE__ */ new Set();
   function set_inspect_effects(v) {
     inspect_effects = v;
   }
-  function source(v, stack2) {
-    var signal = {
+  function source(v) {
+    return {
       f: 0,
       // TODO ideally we could skip this altogether, but it causes type errors
       v,
       reactions: null,
       equals,
-      rv: 0,
-      wv: 0
+      version: 0
     };
-    return signal;
   }
   function state$1(v) {
     return /* @__PURE__ */ push_derived_source(source(v));
   }
   // @__NO_SIDE_EFFECTS__
   function push_derived_source(source2) {
-    if (active_reaction !== null && !untracking && (active_reaction.f & DERIVED) !== 0) {
+    if (active_reaction !== null && (active_reaction.f & DERIVED) !== 0) {
       if (derived_sources === null) {
         set_derived_sources([source2]);
       } else {
@@ -150,7 +166,7 @@ https://svelte.dev/e/state_unsafe_mutation`);
     return source2;
   }
   function set(source2, value) {
-    if (active_reaction !== null && !untracking && is_runes() && (active_reaction.f & (DERIVED | BLOCK_EFFECT)) !== 0 && // If the source was created locally within the current derived, then
+    if (active_reaction !== null && is_runes() && (active_reaction.f & (DERIVED | BLOCK_EFFECT)) !== 0 && // If the source was created locally within the current derived, then
     // we allow the mutation.
     (derived_sources === null || !derived_sources.includes(source2))) {
       state_unsafe_mutation();
@@ -159,26 +175,36 @@ https://svelte.dev/e/state_unsafe_mutation`);
   }
   function internal_set(source2, value) {
     if (!source2.equals(value)) {
-      source2.v;
       source2.v = value;
-      source2.wv = increment_write_version();
+      source2.version = increment_version();
       mark_reactions(source2, DIRTY);
-      if (active_effect !== null && (active_effect.f & CLEAN) !== 0 && (active_effect.f & (BRANCH_EFFECT | ROOT_EFFECT)) === 0) {
-        if (untracked_writes === null) {
-          set_untracked_writes([source2]);
+      if (active_effect !== null && (active_effect.f & CLEAN) !== 0 && (active_effect.f & BRANCH_EFFECT) === 0) {
+        if (new_deps !== null && new_deps.includes(source2)) {
+          set_signal_status(active_effect, DIRTY);
+          schedule_effect(active_effect);
         } else {
-          untracked_writes.push(source2);
+          if (untracked_writes === null) {
+            set_untracked_writes([source2]);
+          } else {
+            untracked_writes.push(source2);
+          }
         }
       }
       if (inspect_effects.size > 0) {
         const inspects = Array.from(inspect_effects);
-        for (const effect2 of inspects) {
-          if ((effect2.f & CLEAN) !== 0) {
-            set_signal_status(effect2, MAYBE_DIRTY);
+        var previously_flushing_effect = is_flushing_effect;
+        set_is_flushing_effect(true);
+        try {
+          for (const effect2 of inspects) {
+            if ((effect2.f & CLEAN) !== 0) {
+              set_signal_status(effect2, MAYBE_DIRTY);
+            }
+            if (check_dirtiness(effect2)) {
+              update_effect(effect2);
+            }
           }
-          if (check_dirtiness(effect2)) {
-            update_effect(effect2);
-          }
+        } finally {
+          set_is_flushing_effect(previously_flushing_effect);
         }
         inspect_effects.clear();
       }
@@ -214,76 +240,41 @@ https://svelte.dev/e/state_unsafe_mutation`);
       }
     }
   }
-  // @__NO_SIDE_EFFECTS__
-  function derived(fn) {
-    var flags = DERIVED | DIRTY;
-    var parent_derived = active_reaction !== null && (active_reaction.f & DERIVED) !== 0 ? (
-      /** @type {Derived} */
-      active_reaction
-    ) : null;
-    if (active_effect === null || parent_derived !== null && (parent_derived.f & UNOWNED) !== 0) {
-      flags |= UNOWNED;
-    } else {
-      active_effect.f |= EFFECT_HAS_DERIVED;
-    }
-    const signal = {
-      ctx: component_context,
-      deps: null,
-      effects: null,
-      equals,
-      f: flags,
-      fn,
-      reactions: null,
-      rv: 0,
-      v: (
-        /** @type {V} */
-        null
-      ),
-      wv: 0,
-      parent: parent_derived ?? active_effect
-    };
-    return signal;
-  }
-  function destroy_derived_effects(derived2) {
-    var effects = derived2.effects;
-    if (effects !== null) {
-      derived2.effects = null;
-      for (var i = 0; i < effects.length; i += 1) {
-        destroy_effect(
-          /** @type {Effect} */
-          effects[i]
-        );
+  function destroy_derived_children(derived) {
+    var children = derived.children;
+    if (children !== null) {
+      derived.children = null;
+      for (var i = 0; i < children.length; i += 1) {
+        var child2 = children[i];
+        if ((child2.f & DERIVED) !== 0) {
+          destroy_derived(
+            /** @type {Derived} */
+            child2
+          );
+        } else {
+          destroy_effect(
+            /** @type {Effect} */
+            child2
+          );
+        }
       }
     }
   }
   let stack = [];
-  function get_derived_parent_effect(derived2) {
-    var parent = derived2.parent;
-    while (parent !== null) {
-      if ((parent.f & DERIVED) === 0) {
-        return (
-          /** @type {Effect} */
-          parent
-        );
-      }
-      parent = parent.parent;
-    }
-    return null;
-  }
-  function execute_derived(derived2) {
+  function execute_derived(derived) {
     var value;
     var prev_active_effect = active_effect;
-    set_active_effect(get_derived_parent_effect(derived2));
+    set_active_effect(derived.parent);
     {
       let prev_inspect_effects = inspect_effects;
       set_inspect_effects(/* @__PURE__ */ new Set());
       try {
-        if (stack.includes(derived2)) {
+        if (stack.includes(derived)) {
           derived_references_self();
         }
-        stack.push(derived2);
-        destroy_derived_effects(derived2);
-        value = update_reaction(derived2);
+        stack.push(derived);
+        destroy_derived_children(derived);
+        value = update_reaction(derived);
       } finally {
         set_active_effect(prev_active_effect);
         set_inspect_effects(prev_inspect_effects);
@@ -292,30 +283,831 @@ https://svelte.dev/e/state_unsafe_mutation`);
     }
     return value;
   }
-  function update_derived(derived2) {
-    var value = execute_derived(derived2);
-    var status = (skip_reaction || (derived2.f & UNOWNED) !== 0) && derived2.deps !== null ? MAYBE_DIRTY : CLEAN;
-    set_signal_status(derived2, status);
-    if (!derived2.equals(value)) {
-      derived2.v = value;
-      derived2.wv = increment_write_version();
+  function update_derived(derived) {
+    var value = execute_derived(derived);
+    var status = (skip_reaction || (derived.f & UNOWNED) !== 0) && derived.deps !== null ? MAYBE_DIRTY : CLEAN;
+    set_signal_status(derived, status);
+    if (!derived.equals(value)) {
+      derived.v = value;
+      derived.version = increment_version();
     }
   }
-  var bold = "font-weight: bold";
-  var normal = "font-weight: normal";
-  function ownership_invalid_mutation(component, owner) {
-    {
-      console.warn(`%c[svelte] ownership_invalid_mutation
-%c${component ? `${component} mutated a value owned by ${owner}. This is strongly discouraged. Consider passing values to child components with \`bind:\`, or use a callback instead` : "Mutating a value outside the component that created it is strongly discouraged. Consider passing values to child components with `bind:`, or use a callback instead"}
-https://svelte.dev/e/ownership_invalid_mutation`, bold, normal);
+  function destroy_derived(signal) {
+    destroy_derived_children(signal);
+    remove_reactions(signal, 0);
+    set_signal_status(signal, DESTROYED);
+    signal.v = signal.children = signal.deps = signal.ctx = signal.reactions = null;
+  }
+  function push_effect(effect2, parent_effect) {
+    var parent_last = parent_effect.last;
+    if (parent_last === null) {
+      parent_effect.last = parent_effect.first = effect2;
+    } else {
+      parent_last.next = effect2;
+      effect2.prev = parent_last;
+      parent_effect.last = effect2;
     }
   }
-  function state_proxy_equality_mismatch(operator) {
+  function create_effect(type, fn, sync, push2 = true) {
+    var is_root = (type & ROOT_EFFECT) !== 0;
+    var parent_effect = active_effect;
     {
-      console.warn(`%c[svelte] state_proxy_equality_mismatch
-%cReactive \`$state(...)\` proxies and the values they proxy have different identities. Because of this, comparisons with \`${operator}\` will produce unexpected results
-https://svelte.dev/e/state_proxy_equality_mismatch`, bold, normal);
+      while (parent_effect !== null && (parent_effect.f & INSPECT_EFFECT) !== 0) {
+        parent_effect = parent_effect.parent;
+      }
     }
+    var effect2 = {
+      ctx: component_context,
+      deps: null,
+      deriveds: null,
+      nodes_start: null,
+      nodes_end: null,
+      f: type | DIRTY,
+      first: null,
+      fn,
+      last: null,
+      next: null,
+      parent: is_root ? null : parent_effect,
+      prev: null,
+      teardown: null,
+      transitions: null,
+      version: 0
+    };
+    {
+      effect2.component_function = dev_current_component_function;
+    }
+    if (sync) {
+      var previously_flushing_effect = is_flushing_effect;
+      try {
+        set_is_flushing_effect(true);
+        update_effect(effect2);
+        effect2.f |= EFFECT_RAN;
+      } catch (e) {
+        destroy_effect(effect2);
+        throw e;
+      } finally {
+        set_is_flushing_effect(previously_flushing_effect);
+      }
+    } else if (fn !== null) {
+      schedule_effect(effect2);
+    }
+    var inert = sync && effect2.deps === null && effect2.first === null && effect2.nodes_start === null && effect2.teardown === null && (effect2.f & EFFECT_HAS_DERIVED) === 0;
+    if (!inert && !is_root && push2) {
+      if (parent_effect !== null) {
+        push_effect(effect2, parent_effect);
+      }
+      if (active_reaction !== null && (active_reaction.f & DERIVED) !== 0) {
+        var derived = (
+          /** @type {Derived} */
+          active_reaction
+        );
+        (derived.children ?? (derived.children = [])).push(effect2);
+      }
+    }
+    return effect2;
+  }
+  function teardown(fn) {
+    const effect2 = create_effect(RENDER_EFFECT, null, false);
+    set_signal_status(effect2, CLEAN);
+    effect2.teardown = fn;
+    return effect2;
+  }
+  function effect_root(fn) {
+    const effect2 = create_effect(ROOT_EFFECT, fn, true);
+    return () => {
+      destroy_effect(effect2);
+    };
+  }
+  function effect(fn) {
+    return create_effect(EFFECT, fn, false);
+  }
+  function template_effect(fn) {
+    {
+      define_property(fn, "name", {
+        value: "{expression}"
+      });
+    }
+    return block(fn);
+  }
+  function block(fn, flags = 0) {
+    return create_effect(RENDER_EFFECT | BLOCK_EFFECT | flags, fn, true);
+  }
+  function branch(fn, push2 = true) {
+    return create_effect(RENDER_EFFECT | BRANCH_EFFECT, fn, true, push2);
+  }
+  function execute_effect_teardown(effect2) {
+    var teardown2 = effect2.teardown;
+    if (teardown2 !== null) {
+      const previous_reaction = active_reaction;
+      set_active_reaction(null);
+      try {
+        teardown2.call(null);
+      } finally {
+        set_active_reaction(previous_reaction);
+      }
+    }
+  }
+  function destroy_effect_deriveds(signal) {
+    var deriveds = signal.deriveds;
+    if (deriveds !== null) {
+      signal.deriveds = null;
+      for (var i = 0; i < deriveds.length; i += 1) {
+        destroy_derived(deriveds[i]);
+      }
+    }
+  }
+  function destroy_effect_children(signal, remove_dom = false) {
+    var effect2 = signal.first;
+    signal.first = signal.last = null;
+    while (effect2 !== null) {
+      var next = effect2.next;
+      destroy_effect(effect2, remove_dom);
+      effect2 = next;
+    }
+  }
+  function destroy_block_effect_children(signal) {
+    var effect2 = signal.first;
+    while (effect2 !== null) {
+      var next = effect2.next;
+      if ((effect2.f & BRANCH_EFFECT) === 0) {
+        destroy_effect(effect2);
+      }
+      effect2 = next;
+    }
+  }
+  function destroy_effect(effect2, remove_dom = true) {
+    var removed = false;
+    if ((remove_dom || (effect2.f & HEAD_EFFECT) !== 0) && effect2.nodes_start !== null) {
+      var node = effect2.nodes_start;
+      var end = effect2.nodes_end;
+      while (node !== null) {
+        var next = node === end ? null : (
+          /** @type {TemplateNode} */
+          /* @__PURE__ */ get_next_sibling(node)
+        );
+        node.remove();
+        node = next;
+      }
+      removed = true;
+    }
+    destroy_effect_children(effect2, remove_dom && !removed);
+    destroy_effect_deriveds(effect2);
+    remove_reactions(effect2, 0);
+    set_signal_status(effect2, DESTROYED);
+    var transitions = effect2.transitions;
+    if (transitions !== null) {
+      for (const transition of transitions) {
+        transition.stop();
+      }
+    }
+    execute_effect_teardown(effect2);
+    var parent = effect2.parent;
+    if (parent !== null && parent.first !== null) {
+      unlink_effect(effect2);
+    }
+    {
+      effect2.component_function = null;
+    }
+    effect2.next = effect2.prev = effect2.teardown = effect2.ctx = effect2.deps = effect2.parent = effect2.fn = effect2.nodes_start = effect2.nodes_end = null;
+  }
+  function unlink_effect(effect2) {
+    var parent = effect2.parent;
+    var prev = effect2.prev;
+    var next = effect2.next;
+    if (prev !== null) prev.next = next;
+    if (next !== null) next.prev = prev;
+    if (parent !== null) {
+      if (parent.first === effect2) parent.first = next;
+      if (parent.last === effect2) parent.last = prev;
+    }
+  }
+  const boundaries = {};
+  const chrome_pattern = /at (?:.+ \()?(.+):(\d+):(\d+)\)?$/;
+  const firefox_pattern = /@(.+):(\d+):(\d+)$/;
+  function get_stack() {
+    const stack2 = new Error().stack;
+    if (!stack2) return null;
+    const entries = [];
+    for (const line of stack2.split("\n")) {
+      let match = chrome_pattern.exec(line) ?? firefox_pattern.exec(line);
+      if (match) {
+        entries.push({
+          file: match[1],
+          line: +match[2],
+          column: +match[3]
+        });
+      }
+    }
+    return entries;
+  }
+  function get_component() {
+    var _a;
+    const stack2 = (_a = get_stack()) == null ? void 0 : _a.slice(4);
+    if (!stack2) return null;
+    for (let i = 0; i < stack2.length; i++) {
+      const entry = stack2[i];
+      const modules = boundaries[entry.file];
+      if (!modules) {
+        if (i === 0) return null;
+        continue;
+      }
+      for (const module of modules) {
+        if (module.end == null) {
+          return null;
+        }
+        if (module.start.line < entry.line && module.end.line > entry.line) {
+          return module.component;
+        }
+      }
+    }
+    return null;
+  }
+  function mark_module_start() {
+    var _a, _b;
+    const start = (_a = get_stack()) == null ? void 0 : _a[2];
+    if (start) {
+      (boundaries[_b = start.file] ?? (boundaries[_b] = [])).push({
+        start,
+        // @ts-expect-error
+        end: null,
+        // @ts-expect-error we add the component at the end, since HMR will overwrite the function
+        component: null
+      });
+    }
+  }
+  function mark_module_end(component) {
+    var _a;
+    const end = (_a = get_stack()) == null ? void 0 : _a[2];
+    if (end) {
+      const boundaries_file = boundaries[end.file];
+      const boundary = boundaries_file[boundaries_file.length - 1];
+      boundary.end = end;
+      boundary.component = component;
+    }
+  }
+  function widen_ownership(from, to) {
+    if (to.owners === null) {
+      return;
+    }
+    while (from) {
+      if (from.owners === null) {
+        to.owners = null;
+        break;
+      }
+      for (const owner of from.owners) {
+        to.owners.add(owner);
+      }
+      from = from.parent;
+    }
+  }
+  function has_owner(metadata, component) {
+    if (metadata.owners === null) {
+      return true;
+    }
+    return metadata.owners.has(component) || metadata.parent !== null && has_owner(metadata.parent, component);
+  }
+  function get_owner(metadata) {
+    var _a;
+    return ((_a = metadata == null ? void 0 : metadata.owners) == null ? void 0 : _a.values().next().value) ?? get_owner(
+      /** @type {ProxyMetadata} */
+      metadata.parent
+    );
+  }
+  function check_ownership(metadata) {
+    const component = get_component();
+    if (component && !has_owner(metadata, component)) {
+      let original = get_owner(metadata);
+      if (original[FILENAME] !== component[FILENAME]) {
+        ownership_invalid_mutation(component[FILENAME], original[FILENAME]);
+      } else {
+        ownership_invalid_mutation();
+      }
+    }
+  }
+  const handled_errors = /* @__PURE__ */ new WeakSet();
+  let is_micro_task_queued = false;
+  let is_flushing_effect = false;
+  function set_is_flushing_effect(value) {
+    is_flushing_effect = value;
+  }
+  let queued_root_effects = [];
+  let flush_count = 0;
+  let dev_effect_stack = [];
+  let active_reaction = null;
+  function set_active_reaction(reaction) {
+    active_reaction = reaction;
+  }
+  let active_effect = null;
+  function set_active_effect(effect2) {
+    active_effect = effect2;
+  }
+  let derived_sources = null;
+  function set_derived_sources(sources) {
+    derived_sources = sources;
+  }
+  let new_deps = null;
+  let skipped_deps = 0;
+  let untracked_writes = null;
+  function set_untracked_writes(value) {
+    untracked_writes = value;
+  }
+  let current_version = 0;
+  let skip_reaction = false;
+  let component_context = null;
+  let dev_current_component_function = null;
+  function increment_version() {
+    return ++current_version;
+  }
+  function is_runes() {
+    return !legacy_mode_flag;
+  }
+  function check_dirtiness(reaction) {
+    var _a, _b;
+    var flags = reaction.f;
+    if ((flags & DIRTY) !== 0) {
+      return true;
+    }
+    if ((flags & MAYBE_DIRTY) !== 0) {
+      var dependencies = reaction.deps;
+      var is_unowned = (flags & UNOWNED) !== 0;
+      if (dependencies !== null) {
+        var i;
+        if ((flags & DISCONNECTED) !== 0) {
+          for (i = 0; i < dependencies.length; i++) {
+            ((_a = dependencies[i]).reactions ?? (_a.reactions = [])).push(reaction);
+          }
+          reaction.f ^= DISCONNECTED;
+        }
+        for (i = 0; i < dependencies.length; i++) {
+          var dependency = dependencies[i];
+          if (check_dirtiness(
+            /** @type {Derived} */
+            dependency
+          )) {
+            update_derived(
+              /** @type {Derived} */
+              dependency
+            );
+          }
+          if (is_unowned && active_effect !== null && !skip_reaction && !((_b = dependency == null ? void 0 : dependency.reactions) == null ? void 0 : _b.includes(reaction))) {
+            (dependency.reactions ?? (dependency.reactions = [])).push(reaction);
+          }
+          if (dependency.version > reaction.version) {
+            return true;
+          }
+        }
+      }
+      if (!is_unowned) {
+        set_signal_status(reaction, CLEAN);
+      }
+    }
+    return false;
+  }
+  function handle_error(error, effect2, component_context2) {
+    var _a, _b;
+    if (handled_errors.has(error) || component_context2 === null) {
+      throw error;
+    }
+    const component_stack = [];
+    const effect_name = (_a = effect2.fn) == null ? void 0 : _a.name;
+    if (effect_name) {
+      component_stack.push(effect_name);
+    }
+    let current_context = component_context2;
+    while (current_context !== null) {
+      {
+        var filename = (_b = current_context.function) == null ? void 0 : _b[FILENAME];
+        if (filename) {
+          const file = filename.split("/").pop();
+          component_stack.push(file);
+        }
+      }
+      current_context = current_context.p;
+    }
+    const indent = /Firefox/.test(navigator.userAgent) ? "  " : "	";
+    define_property(error, "message", {
+      value: error.message + `
+${component_stack.map((name) => `
+${indent}in ${name}`).join("")}
+`
+    });
+    const stack2 = error.stack;
+    if (stack2) {
+      const lines = stack2.split("\n");
+      const new_lines = [];
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        if (line.includes("svelte/src/internal")) {
+          continue;
+        }
+        new_lines.push(line);
+      }
+      define_property(error, "stack", {
+        value: error.stack + new_lines.join("\n")
+      });
+    }
+    handled_errors.add(error);
+    throw error;
+  }
+  function update_reaction(reaction) {
+    var _a;
+    var previous_deps = new_deps;
+    var previous_skipped_deps = skipped_deps;
+    var previous_untracked_writes = untracked_writes;
+    var previous_reaction = active_reaction;
+    var previous_skip_reaction = skip_reaction;
+    var prev_derived_sources = derived_sources;
+    var previous_component_context = component_context;
+    var flags = reaction.f;
+    new_deps = /** @type {null | Value[]} */
+    null;
+    skipped_deps = 0;
+    untracked_writes = null;
+    active_reaction = (flags & (BRANCH_EFFECT | ROOT_EFFECT)) === 0 ? reaction : null;
+    skip_reaction = !is_flushing_effect && (flags & UNOWNED) !== 0;
+    derived_sources = null;
+    component_context = reaction.ctx;
+    try {
+      var result = (
+        /** @type {Function} */
+        (0, reaction.fn)()
+      );
+      var deps = reaction.deps;
+      if (new_deps !== null) {
+        var i;
+        remove_reactions(reaction, skipped_deps);
+        if (deps !== null && skipped_deps > 0) {
+          deps.length = skipped_deps + new_deps.length;
+          for (i = 0; i < new_deps.length; i++) {
+            deps[skipped_deps + i] = new_deps[i];
+          }
+        } else {
+          reaction.deps = deps = new_deps;
+        }
+        if (!skip_reaction) {
+          for (i = skipped_deps; i < deps.length; i++) {
+            ((_a = deps[i]).reactions ?? (_a.reactions = [])).push(reaction);
+          }
+        }
+      } else if (deps !== null && skipped_deps < deps.length) {
+        remove_reactions(reaction, skipped_deps);
+        deps.length = skipped_deps;
+      }
+      return result;
+    } finally {
+      new_deps = previous_deps;
+      skipped_deps = previous_skipped_deps;
+      untracked_writes = previous_untracked_writes;
+      active_reaction = previous_reaction;
+      skip_reaction = previous_skip_reaction;
+      derived_sources = prev_derived_sources;
+      component_context = previous_component_context;
+    }
+  }
+  function remove_reaction(signal, dependency) {
+    let reactions = dependency.reactions;
+    if (reactions !== null) {
+      var index = reactions.indexOf(signal);
+      if (index !== -1) {
+        var new_length = reactions.length - 1;
+        if (new_length === 0) {
+          reactions = dependency.reactions = null;
+        } else {
+          reactions[index] = reactions[new_length];
+          reactions.pop();
+        }
+      }
+    }
+    if (reactions === null && (dependency.f & DERIVED) !== 0 && // Destroying a child effect while updating a parent effect can cause a dependency to appear
+    // to be unused, when in fact it is used by the currently-updating parent. Checking `new_deps`
+    // allows us to skip the expensive work of disconnecting and immediately reconnecting it
+    (new_deps === null || !new_deps.includes(dependency))) {
+      set_signal_status(dependency, MAYBE_DIRTY);
+      if ((dependency.f & (UNOWNED | DISCONNECTED)) === 0) {
+        dependency.f ^= DISCONNECTED;
+      }
+      remove_reactions(
+        /** @type {Derived} **/
+        dependency,
+        0
+      );
+    }
+  }
+  function remove_reactions(signal, start_index) {
+    var dependencies = signal.deps;
+    if (dependencies === null) return;
+    for (var i = start_index; i < dependencies.length; i++) {
+      remove_reaction(signal, dependencies[i]);
+    }
+  }
+  function update_effect(effect2) {
+    var flags = effect2.f;
+    if ((flags & DESTROYED) !== 0) {
+      return;
+    }
+    set_signal_status(effect2, CLEAN);
+    var previous_effect = active_effect;
+    var previous_component_context = component_context;
+    active_effect = effect2;
+    {
+      var previous_component_fn = dev_current_component_function;
+      dev_current_component_function = effect2.component_function;
+    }
+    try {
+      if ((flags & BLOCK_EFFECT) !== 0) {
+        destroy_block_effect_children(effect2);
+      } else {
+        destroy_effect_children(effect2);
+      }
+      destroy_effect_deriveds(effect2);
+      execute_effect_teardown(effect2);
+      var teardown2 = update_reaction(effect2);
+      effect2.teardown = typeof teardown2 === "function" ? teardown2 : null;
+      effect2.version = current_version;
+      if (DEV) {
+        dev_effect_stack.push(effect2);
+      }
+    } catch (error) {
+      handle_error(
+        /** @type {Error} */
+        error,
+        effect2,
+        previous_component_context
+      );
+    } finally {
+      active_effect = previous_effect;
+      {
+        dev_current_component_function = previous_component_fn;
+      }
+    }
+  }
+  function infinite_loop_guard() {
+    if (flush_count > 1e3) {
+      flush_count = 0;
+      {
+        try {
+          effect_update_depth_exceeded();
+        } catch (error) {
+          define_property(error, "stack", {
+            value: ""
+          });
+          console.error(
+            "Last ten effects were: ",
+            dev_effect_stack.slice(-10).map((d) => d.fn)
+          );
+          dev_effect_stack = [];
+          throw error;
+        }
+      }
+    }
+    flush_count++;
+  }
+  function flush_queued_root_effects(root_effects) {
+    var length = root_effects.length;
+    if (length === 0) {
+      return;
+    }
+    infinite_loop_guard();
+    var previously_flushing_effect = is_flushing_effect;
+    is_flushing_effect = true;
+    try {
+      for (var i = 0; i < length; i++) {
+        var effect2 = root_effects[i];
+        if ((effect2.f & CLEAN) === 0) {
+          effect2.f ^= CLEAN;
+        }
+        var collected_effects = [];
+        process_effects(effect2, collected_effects);
+        flush_queued_effects(collected_effects);
+      }
+    } finally {
+      is_flushing_effect = previously_flushing_effect;
+    }
+  }
+  function flush_queued_effects(effects) {
+    var length = effects.length;
+    if (length === 0) return;
+    for (var i = 0; i < length; i++) {
+      var effect2 = effects[i];
+      if ((effect2.f & (DESTROYED | INERT)) === 0 && check_dirtiness(effect2)) {
+        update_effect(effect2);
+        if (effect2.deps === null && effect2.first === null && effect2.nodes_start === null) {
+          if (effect2.teardown === null) {
+            unlink_effect(effect2);
+          } else {
+            effect2.fn = null;
+          }
+        }
+      }
+    }
+  }
+  function process_deferred() {
+    is_micro_task_queued = false;
+    if (flush_count > 1001) {
+      return;
+    }
+    const previous_queued_root_effects = queued_root_effects;
+    queued_root_effects = [];
+    flush_queued_root_effects(previous_queued_root_effects);
+    if (!is_micro_task_queued) {
+      flush_count = 0;
+      {
+        dev_effect_stack = [];
+      }
+    }
+  }
+  function schedule_effect(signal) {
+    {
+      if (!is_micro_task_queued) {
+        is_micro_task_queued = true;
+        queueMicrotask(process_deferred);
+      }
+    }
+    var effect2 = signal;
+    while (effect2.parent !== null) {
+      effect2 = effect2.parent;
+      var flags = effect2.f;
+      if ((flags & (ROOT_EFFECT | BRANCH_EFFECT)) !== 0) {
+        if ((flags & CLEAN) === 0) return;
+        effect2.f ^= CLEAN;
+      }
+    }
+    queued_root_effects.push(effect2);
+  }
+  function process_effects(effect2, collected_effects) {
+    var current_effect = effect2.first;
+    var effects = [];
+    main_loop: while (current_effect !== null) {
+      var flags = current_effect.f;
+      var is_branch = (flags & BRANCH_EFFECT) !== 0;
+      var is_skippable_branch = is_branch && (flags & CLEAN) !== 0;
+      if (!is_skippable_branch && (flags & INERT) === 0) {
+        if ((flags & RENDER_EFFECT) !== 0) {
+          if (is_branch) {
+            current_effect.f ^= CLEAN;
+          } else if (check_dirtiness(current_effect)) {
+            update_effect(current_effect);
+          }
+          var child2 = current_effect.first;
+          if (child2 !== null) {
+            current_effect = child2;
+            continue;
+          }
+        } else if ((flags & EFFECT) !== 0) {
+          effects.push(current_effect);
+        }
+      }
+      var sibling = current_effect.next;
+      if (sibling === null) {
+        let parent = current_effect.parent;
+        while (parent !== null) {
+          if (effect2 === parent) {
+            break main_loop;
+          }
+          var parent_sibling = parent.next;
+          if (parent_sibling !== null) {
+            current_effect = parent_sibling;
+            continue main_loop;
+          }
+          parent = parent.parent;
+        }
+      }
+      current_effect = sibling;
+    }
+    for (var i = 0; i < effects.length; i++) {
+      child2 = effects[i];
+      collected_effects.push(child2);
+      process_effects(child2, collected_effects);
+    }
+  }
+  function get(signal) {
+    var _a;
+    var flags = signal.f;
+    var is_derived = (flags & DERIVED) !== 0;
+    if (is_derived && (flags & DESTROYED) !== 0) {
+      var value = execute_derived(
+        /** @type {Derived} */
+        signal
+      );
+      destroy_derived(
+        /** @type {Derived} */
+        signal
+      );
+      return value;
+    }
+    if (active_reaction !== null) {
+      if (derived_sources !== null && derived_sources.includes(signal)) {
+        state_unsafe_local_read();
+      }
+      var deps = active_reaction.deps;
+      if (new_deps === null && deps !== null && deps[skipped_deps] === signal) {
+        skipped_deps++;
+      } else if (new_deps === null) {
+        new_deps = [signal];
+      } else {
+        new_deps.push(signal);
+      }
+      if (untracked_writes !== null && active_effect !== null && (active_effect.f & CLEAN) !== 0 && (active_effect.f & BRANCH_EFFECT) === 0 && untracked_writes.includes(signal)) {
+        set_signal_status(active_effect, DIRTY);
+        schedule_effect(active_effect);
+      }
+    } else if (is_derived && /** @type {Derived} */
+    signal.deps === null) {
+      var derived = (
+        /** @type {Derived} */
+        signal
+      );
+      var parent = derived.parent;
+      if (parent !== null && !((_a = parent.deriveds) == null ? void 0 : _a.includes(derived))) {
+        (parent.deriveds ?? (parent.deriveds = [])).push(derived);
+      }
+    }
+    if (is_derived) {
+      derived = /** @type {Derived} */
+      signal;
+      if (check_dirtiness(derived)) {
+        update_derived(derived);
+      }
+    }
+    return signal.v;
+  }
+  const STATUS_MASK = ~(DIRTY | MAYBE_DIRTY | CLEAN);
+  function set_signal_status(signal, status) {
+    signal.f = signal.f & STATUS_MASK | status;
+  }
+  function push(props, runes = false, fn) {
+    component_context = {
+      p: component_context,
+      c: null,
+      e: null,
+      m: false,
+      s: props,
+      x: null,
+      l: null
+    };
+    {
+      component_context.function = fn;
+      dev_current_component_function = fn;
+    }
+  }
+  function pop(component) {
+    var _a;
+    const context_stack_item = component_context;
+    if (context_stack_item !== null) {
+      if (component !== void 0) {
+        context_stack_item.x = component;
+      }
+      const component_effects = context_stack_item.e;
+      if (component_effects !== null) {
+        var previous_effect = active_effect;
+        var previous_reaction = active_reaction;
+        context_stack_item.e = null;
+        try {
+          for (var i = 0; i < component_effects.length; i++) {
+            var component_effect = component_effects[i];
+            set_active_effect(component_effect.effect);
+            set_active_reaction(component_effect.reaction);
+            effect(component_effect.fn);
+          }
+        } finally {
+          set_active_effect(previous_effect);
+          set_active_reaction(previous_reaction);
+        }
+      }
+      component_context = context_stack_item.p;
+      {
+        dev_current_component_function = ((_a = context_stack_item.p) == null ? void 0 : _a.function) ?? null;
+      }
+      context_stack_item.m = true;
+    }
+    return component || /** @type {T} */
+    {};
+  }
+  {
+    let throw_rune_error = function(rune) {
+      if (!(rune in globalThis)) {
+        let value;
+        Object.defineProperty(globalThis, rune, {
+          configurable: true,
+          // eslint-disable-next-line getter-return
+          get: () => {
+            if (value !== void 0) {
+              return value;
+            }
+            rune_outside_svelte(rune);
+          },
+          set: (v) => {
+            value = v;
+          }
+        });
+      }
+    };
+    throw_rune_error("$state");
+    throw_rune_error("$effect");
+    throw_rune_error("$derived");
+    throw_rune_error("$inspect");
+    throw_rune_error("$props");
+    throw_rune_error("$bindable");
   }
   function proxy(value, parent = null, prev) {
     var _a, _b;
@@ -544,11 +1336,9 @@ https://svelte.dev/e/state_proxy_equality_mismatch`, bold, normal);
     array_prototype2.indexOf = function(item, from_index) {
       const index = indexOf.call(this, item, from_index);
       if (index === -1) {
-        for (let i = from_index ?? 0; i < this.length; i += 1) {
-          if (get_proxied_value(this[i]) === item) {
-            state_proxy_equality_mismatch("array.indexOf(...)");
-            break;
-          }
+        const test = indexOf.call(get_proxied_value(this), get_proxied_value(item), from_index);
+        if (test !== -1) {
+          state_proxy_equality_mismatch("array.indexOf(...)");
         }
       }
       return index;
@@ -556,11 +1346,13 @@ https://svelte.dev/e/state_proxy_equality_mismatch`, bold, normal);
     array_prototype2.lastIndexOf = function(item, from_index) {
       const index = lastIndexOf.call(this, item, from_index ?? this.length - 1);
       if (index === -1) {
-        for (let i = 0; i <= (from_index ?? this.length - 1); i += 1) {
-          if (get_proxied_value(this[i]) === item) {
-            state_proxy_equality_mismatch("array.lastIndexOf(...)");
-            break;
-          }
+        const test = lastIndexOf.call(
+          get_proxied_value(this),
+          get_proxied_value(item),
+          from_index ?? this.length - 1
+        );
+        if (test !== -1) {
+          state_proxy_equality_mismatch("array.lastIndexOf(...)");
         }
       }
       return index;
@@ -568,11 +1360,9 @@ https://svelte.dev/e/state_proxy_equality_mismatch`, bold, normal);
     array_prototype2.includes = function(item, from_index) {
       const has = includes.call(this, item, from_index);
       if (!has) {
-        for (let i = 0; i < this.length; i += 1) {
-          if (get_proxied_value(this[i]) === item) {
-            state_proxy_equality_mismatch("array.includes(...)");
-            break;
-          }
+        const test = includes.call(get_proxied_value(this), get_proxied_value(item), from_index);
+        if (test) {
+          state_proxy_equality_mismatch("array.includes(...)");
         }
       }
       return has;
@@ -584,7 +1374,6 @@ https://svelte.dev/e/state_proxy_equality_mismatch`, bold, normal);
     };
   }
   var $window;
-  var is_firefox;
   var first_child_getter;
   var next_sibling_getter;
   function init_operations() {
@@ -592,13 +1381,12 @@ https://svelte.dev/e/state_proxy_equality_mismatch`, bold, normal);
       return;
     }
     $window = window;
-    is_firefox = /Firefox/.test(navigator.userAgent);
     var element_prototype = Element.prototype;
     var node_prototype = Node.prototype;
     first_child_getter = get_descriptor(node_prototype, "firstChild").get;
     next_sibling_getter = get_descriptor(node_prototype, "nextSibling").get;
     element_prototype.__click = void 0;
-    element_prototype.__className = void 0;
+    element_prototype.__className = "";
     element_prototype.__attributes = null;
     element_prototype.__styles = null;
     element_prototype.__e = void 0;
@@ -623,927 +1411,6 @@ https://svelte.dev/e/state_proxy_equality_mismatch`, bold, normal);
     {
       return /* @__PURE__ */ get_first_child(node);
     }
-  }
-  const handled_errors = /* @__PURE__ */ new WeakSet();
-  let is_throwing_error = false;
-  let is_flushing = false;
-  let last_scheduled_effect = null;
-  let is_updating_effect = false;
-  let queued_root_effects = [];
-  let dev_effect_stack = [];
-  let active_reaction = null;
-  let untracking = false;
-  function set_active_reaction(reaction) {
-    active_reaction = reaction;
-  }
-  let active_effect = null;
-  function set_active_effect(effect2) {
-    active_effect = effect2;
-  }
-  let derived_sources = null;
-  function set_derived_sources(sources) {
-    derived_sources = sources;
-  }
-  let new_deps = null;
-  let skipped_deps = 0;
-  let untracked_writes = null;
-  function set_untracked_writes(value) {
-    untracked_writes = value;
-  }
-  let write_version = 1;
-  let read_version = 0;
-  let skip_reaction = false;
-  function increment_write_version() {
-    return ++write_version;
-  }
-  function check_dirtiness(reaction) {
-    var _a;
-    var flags = reaction.f;
-    if ((flags & DIRTY) !== 0) {
-      return true;
-    }
-    if ((flags & MAYBE_DIRTY) !== 0) {
-      var dependencies = reaction.deps;
-      var is_unowned = (flags & UNOWNED) !== 0;
-      if (dependencies !== null) {
-        var i;
-        var dependency;
-        var is_disconnected = (flags & DISCONNECTED) !== 0;
-        var is_unowned_connected = is_unowned && active_effect !== null && !skip_reaction;
-        var length = dependencies.length;
-        if (is_disconnected || is_unowned_connected) {
-          var derived2 = (
-            /** @type {Derived} */
-            reaction
-          );
-          var parent = derived2.parent;
-          for (i = 0; i < length; i++) {
-            dependency = dependencies[i];
-            if (is_disconnected || !((_a = dependency == null ? void 0 : dependency.reactions) == null ? void 0 : _a.includes(derived2))) {
-              (dependency.reactions ?? (dependency.reactions = [])).push(derived2);
-            }
-          }
-          if (is_disconnected) {
-            derived2.f ^= DISCONNECTED;
-          }
-          if (is_unowned_connected && parent !== null && (parent.f & UNOWNED) === 0) {
-            derived2.f ^= UNOWNED;
-          }
-        }
-        for (i = 0; i < length; i++) {
-          dependency = dependencies[i];
-          if (check_dirtiness(
-            /** @type {Derived} */
-            dependency
-          )) {
-            update_derived(
-              /** @type {Derived} */
-              dependency
-            );
-          }
-          if (dependency.wv > reaction.wv) {
-            return true;
-          }
-        }
-      }
-      if (!is_unowned || active_effect !== null && !skip_reaction) {
-        set_signal_status(reaction, CLEAN);
-      }
-    }
-    return false;
-  }
-  function propagate_error(error, effect2) {
-    var current = effect2;
-    while (current !== null) {
-      if ((current.f & BOUNDARY_EFFECT) !== 0) {
-        try {
-          current.fn(error);
-          return;
-        } catch {
-          current.f ^= BOUNDARY_EFFECT;
-        }
-      }
-      current = current.parent;
-    }
-    is_throwing_error = false;
-    throw error;
-  }
-  function should_rethrow_error(effect2) {
-    return (effect2.f & DESTROYED) === 0 && (effect2.parent === null || (effect2.parent.f & BOUNDARY_EFFECT) === 0);
-  }
-  function handle_error(error, effect2, previous_effect, component_context2) {
-    var _a, _b;
-    if (is_throwing_error) {
-      if (previous_effect === null) {
-        is_throwing_error = false;
-      }
-      if (should_rethrow_error(effect2)) {
-        throw error;
-      }
-      return;
-    }
-    if (previous_effect !== null) {
-      is_throwing_error = true;
-    }
-    if (component_context2 === null || !(error instanceof Error) || handled_errors.has(error)) {
-      propagate_error(error, effect2);
-      return;
-    }
-    handled_errors.add(error);
-    const component_stack = [];
-    const effect_name = (_a = effect2.fn) == null ? void 0 : _a.name;
-    if (effect_name) {
-      component_stack.push(effect_name);
-    }
-    let current_context = component_context2;
-    while (current_context !== null) {
-      {
-        var filename = (_b = current_context.function) == null ? void 0 : _b[FILENAME];
-        if (filename) {
-          const file = filename.split("/").pop();
-          component_stack.push(file);
-        }
-      }
-      current_context = current_context.p;
-    }
-    const indent = is_firefox ? "  " : "	";
-    define_property(error, "message", {
-      value: error.message + `
-${component_stack.map((name) => `
-${indent}in ${name}`).join("")}
-`
-    });
-    define_property(error, "component_stack", {
-      value: component_stack
-    });
-    const stack2 = error.stack;
-    if (stack2) {
-      const lines = stack2.split("\n");
-      const new_lines = [];
-      for (let i = 0; i < lines.length; i++) {
-        const line = lines[i];
-        if (line.includes("svelte/src/internal")) {
-          continue;
-        }
-        new_lines.push(line);
-      }
-      define_property(error, "stack", {
-        value: new_lines.join("\n")
-      });
-    }
-    propagate_error(error, effect2);
-    if (should_rethrow_error(effect2)) {
-      throw error;
-    }
-  }
-  function schedule_possible_effect_self_invalidation(signal, effect2, root2 = true) {
-    var reactions = signal.reactions;
-    if (reactions === null) return;
-    for (var i = 0; i < reactions.length; i++) {
-      var reaction = reactions[i];
-      if ((reaction.f & DERIVED) !== 0) {
-        schedule_possible_effect_self_invalidation(
-          /** @type {Derived} */
-          reaction,
-          effect2,
-          false
-        );
-      } else if (effect2 === reaction) {
-        if (root2) {
-          set_signal_status(reaction, DIRTY);
-        } else if ((reaction.f & CLEAN) !== 0) {
-          set_signal_status(reaction, MAYBE_DIRTY);
-        }
-        schedule_effect(
-          /** @type {Effect} */
-          reaction
-        );
-      }
-    }
-  }
-  function update_reaction(reaction) {
-    var _a;
-    var previous_deps = new_deps;
-    var previous_skipped_deps = skipped_deps;
-    var previous_untracked_writes = untracked_writes;
-    var previous_reaction = active_reaction;
-    var previous_skip_reaction = skip_reaction;
-    var prev_derived_sources = derived_sources;
-    var previous_component_context = component_context;
-    var previous_untracking = untracking;
-    var flags = reaction.f;
-    new_deps = /** @type {null | Value[]} */
-    null;
-    skipped_deps = 0;
-    untracked_writes = null;
-    skip_reaction = (flags & UNOWNED) !== 0 && (untracking || !is_updating_effect || active_reaction === null);
-    active_reaction = (flags & (BRANCH_EFFECT | ROOT_EFFECT)) === 0 ? reaction : null;
-    derived_sources = null;
-    set_component_context(reaction.ctx);
-    untracking = false;
-    read_version++;
-    try {
-      var result = (
-        /** @type {Function} */
-        (0, reaction.fn)()
-      );
-      var deps = reaction.deps;
-      if (new_deps !== null) {
-        var i;
-        remove_reactions(reaction, skipped_deps);
-        if (deps !== null && skipped_deps > 0) {
-          deps.length = skipped_deps + new_deps.length;
-          for (i = 0; i < new_deps.length; i++) {
-            deps[skipped_deps + i] = new_deps[i];
-          }
-        } else {
-          reaction.deps = deps = new_deps;
-        }
-        if (!skip_reaction) {
-          for (i = skipped_deps; i < deps.length; i++) {
-            ((_a = deps[i]).reactions ?? (_a.reactions = [])).push(reaction);
-          }
-        }
-      } else if (deps !== null && skipped_deps < deps.length) {
-        remove_reactions(reaction, skipped_deps);
-        deps.length = skipped_deps;
-      }
-      if (is_runes() && untracked_writes !== null && !untracking && deps !== null && (reaction.f & (DERIVED | MAYBE_DIRTY | DIRTY)) === 0) {
-        for (i = 0; i < /** @type {Source[]} */
-        untracked_writes.length; i++) {
-          schedule_possible_effect_self_invalidation(
-            untracked_writes[i],
-            /** @type {Effect} */
-            reaction
-          );
-        }
-      }
-      if (previous_reaction !== null) {
-        read_version++;
-      }
-      return result;
-    } finally {
-      new_deps = previous_deps;
-      skipped_deps = previous_skipped_deps;
-      untracked_writes = previous_untracked_writes;
-      active_reaction = previous_reaction;
-      skip_reaction = previous_skip_reaction;
-      derived_sources = prev_derived_sources;
-      set_component_context(previous_component_context);
-      untracking = previous_untracking;
-    }
-  }
-  function remove_reaction(signal, dependency) {
-    let reactions = dependency.reactions;
-    if (reactions !== null) {
-      var index = index_of.call(reactions, signal);
-      if (index !== -1) {
-        var new_length = reactions.length - 1;
-        if (new_length === 0) {
-          reactions = dependency.reactions = null;
-        } else {
-          reactions[index] = reactions[new_length];
-          reactions.pop();
-        }
-      }
-    }
-    if (reactions === null && (dependency.f & DERIVED) !== 0 && // Destroying a child effect while updating a parent effect can cause a dependency to appear
-    // to be unused, when in fact it is used by the currently-updating parent. Checking `new_deps`
-    // allows us to skip the expensive work of disconnecting and immediately reconnecting it
-    (new_deps === null || !new_deps.includes(dependency))) {
-      set_signal_status(dependency, MAYBE_DIRTY);
-      if ((dependency.f & (UNOWNED | DISCONNECTED)) === 0) {
-        dependency.f ^= DISCONNECTED;
-      }
-      destroy_derived_effects(
-        /** @type {Derived} **/
-        dependency
-      );
-      remove_reactions(
-        /** @type {Derived} **/
-        dependency,
-        0
-      );
-    }
-  }
-  function remove_reactions(signal, start_index) {
-    var dependencies = signal.deps;
-    if (dependencies === null) return;
-    for (var i = start_index; i < dependencies.length; i++) {
-      remove_reaction(signal, dependencies[i]);
-    }
-  }
-  function update_effect(effect2) {
-    var flags = effect2.f;
-    if ((flags & DESTROYED) !== 0) {
-      return;
-    }
-    set_signal_status(effect2, CLEAN);
-    var previous_effect = active_effect;
-    var previous_component_context = component_context;
-    var was_updating_effect = is_updating_effect;
-    active_effect = effect2;
-    is_updating_effect = true;
-    {
-      var previous_component_fn = dev_current_component_function;
-      set_dev_current_component_function(effect2.component_function);
-    }
-    try {
-      if ((flags & BLOCK_EFFECT) !== 0) {
-        destroy_block_effect_children(effect2);
-      } else {
-        destroy_effect_children(effect2);
-      }
-      execute_effect_teardown(effect2);
-      var teardown2 = update_reaction(effect2);
-      effect2.teardown = typeof teardown2 === "function" ? teardown2 : null;
-      effect2.wv = write_version;
-      var deps = effect2.deps;
-      var dep;
-      if (DEV && tracing_mode_flag && (effect2.f & DIRTY) !== 0 && deps !== null) ;
-      if (DEV) {
-        dev_effect_stack.push(effect2);
-      }
-    } catch (error) {
-      handle_error(error, effect2, previous_effect, previous_component_context || effect2.ctx);
-    } finally {
-      is_updating_effect = was_updating_effect;
-      active_effect = previous_effect;
-      {
-        set_dev_current_component_function(previous_component_fn);
-      }
-    }
-  }
-  function log_effect_stack() {
-    console.error(
-      "Last ten effects were: ",
-      dev_effect_stack.slice(-10).map((d) => d.fn)
-    );
-    dev_effect_stack = [];
-  }
-  function infinite_loop_guard() {
-    try {
-      effect_update_depth_exceeded();
-    } catch (error) {
-      {
-        define_property(error, "stack", {
-          value: ""
-        });
-      }
-      if (last_scheduled_effect !== null) {
-        {
-          try {
-            handle_error(error, last_scheduled_effect, null, null);
-          } catch (e) {
-            log_effect_stack();
-            throw e;
-          }
-        }
-      } else {
-        {
-          log_effect_stack();
-        }
-        throw error;
-      }
-    }
-  }
-  function flush_queued_root_effects() {
-    try {
-      var flush_count = 0;
-      while (queued_root_effects.length > 0) {
-        if (flush_count++ > 1e3) {
-          infinite_loop_guard();
-        }
-        var root_effects = queued_root_effects;
-        var length = root_effects.length;
-        queued_root_effects = [];
-        for (var i = 0; i < length; i++) {
-          var root2 = root_effects[i];
-          if ((root2.f & CLEAN) === 0) {
-            root2.f ^= CLEAN;
-          }
-          var collected_effects = process_effects(root2);
-          flush_queued_effects(collected_effects);
-        }
-      }
-    } finally {
-      is_flushing = false;
-      last_scheduled_effect = null;
-      {
-        dev_effect_stack = [];
-      }
-    }
-  }
-  function flush_queued_effects(effects) {
-    var length = effects.length;
-    if (length === 0) return;
-    for (var i = 0; i < length; i++) {
-      var effect2 = effects[i];
-      if ((effect2.f & (DESTROYED | INERT)) === 0) {
-        try {
-          if (check_dirtiness(effect2)) {
-            update_effect(effect2);
-            if (effect2.deps === null && effect2.first === null && effect2.nodes_start === null) {
-              if (effect2.teardown === null) {
-                unlink_effect(effect2);
-              } else {
-                effect2.fn = null;
-              }
-            }
-          }
-        } catch (error) {
-          handle_error(error, effect2, null, effect2.ctx);
-        }
-      }
-    }
-  }
-  function schedule_effect(signal) {
-    if (!is_flushing) {
-      is_flushing = true;
-      queueMicrotask(flush_queued_root_effects);
-    }
-    var effect2 = last_scheduled_effect = signal;
-    while (effect2.parent !== null) {
-      effect2 = effect2.parent;
-      var flags = effect2.f;
-      if ((flags & (ROOT_EFFECT | BRANCH_EFFECT)) !== 0) {
-        if ((flags & CLEAN) === 0) return;
-        effect2.f ^= CLEAN;
-      }
-    }
-    queued_root_effects.push(effect2);
-  }
-  function process_effects(root2) {
-    var effects = [];
-    var effect2 = root2.first;
-    while (effect2 !== null) {
-      var flags = effect2.f;
-      var is_branch = (flags & BRANCH_EFFECT) !== 0;
-      var is_skippable_branch = is_branch && (flags & CLEAN) !== 0;
-      if (!is_skippable_branch && (flags & INERT) === 0) {
-        if ((flags & EFFECT) !== 0) {
-          effects.push(effect2);
-        } else if (is_branch) {
-          effect2.f ^= CLEAN;
-        } else {
-          var previous_active_reaction = active_reaction;
-          try {
-            active_reaction = effect2;
-            if (check_dirtiness(effect2)) {
-              update_effect(effect2);
-            }
-          } catch (error) {
-            handle_error(error, effect2, null, effect2.ctx);
-          } finally {
-            active_reaction = previous_active_reaction;
-          }
-        }
-        var child2 = effect2.first;
-        if (child2 !== null) {
-          effect2 = child2;
-          continue;
-        }
-      }
-      var parent = effect2.parent;
-      effect2 = effect2.next;
-      while (effect2 === null && parent !== null) {
-        effect2 = parent.next;
-        parent = parent.parent;
-      }
-    }
-    return effects;
-  }
-  function get(signal) {
-    var flags = signal.f;
-    var is_derived = (flags & DERIVED) !== 0;
-    if (active_reaction !== null && !untracking) {
-      if (derived_sources !== null && derived_sources.includes(signal)) {
-        state_unsafe_local_read();
-      }
-      var deps = active_reaction.deps;
-      if (signal.rv < read_version) {
-        signal.rv = read_version;
-        if (new_deps === null && deps !== null && deps[skipped_deps] === signal) {
-          skipped_deps++;
-        } else if (new_deps === null) {
-          new_deps = [signal];
-        } else if (!skip_reaction || !new_deps.includes(signal)) {
-          new_deps.push(signal);
-        }
-      }
-    } else if (is_derived && /** @type {Derived} */
-    signal.deps === null && /** @type {Derived} */
-    signal.effects === null) {
-      var derived2 = (
-        /** @type {Derived} */
-        signal
-      );
-      var parent = derived2.parent;
-      if (parent !== null && (parent.f & UNOWNED) === 0) {
-        derived2.f ^= UNOWNED;
-      }
-    }
-    if (is_derived) {
-      derived2 = /** @type {Derived} */
-      signal;
-      if (check_dirtiness(derived2)) {
-        update_derived(derived2);
-      }
-    }
-    return signal.v;
-  }
-  const STATUS_MASK = -7169;
-  function set_signal_status(signal, status) {
-    signal.f = signal.f & STATUS_MASK | status;
-  }
-  function push_effect(effect2, parent_effect) {
-    var parent_last = parent_effect.last;
-    if (parent_last === null) {
-      parent_effect.last = parent_effect.first = effect2;
-    } else {
-      parent_last.next = effect2;
-      effect2.prev = parent_last;
-      parent_effect.last = effect2;
-    }
-  }
-  function create_effect(type, fn, sync, push2 = true) {
-    var is_root = (type & ROOT_EFFECT) !== 0;
-    var parent_effect = active_effect;
-    {
-      while (parent_effect !== null && (parent_effect.f & INSPECT_EFFECT) !== 0) {
-        parent_effect = parent_effect.parent;
-      }
-    }
-    var effect2 = {
-      ctx: component_context,
-      deps: null,
-      nodes_start: null,
-      nodes_end: null,
-      f: type | DIRTY,
-      first: null,
-      fn,
-      last: null,
-      next: null,
-      parent: is_root ? null : parent_effect,
-      prev: null,
-      teardown: null,
-      transitions: null,
-      wv: 0
-    };
-    {
-      effect2.component_function = dev_current_component_function;
-    }
-    if (sync) {
-      try {
-        update_effect(effect2);
-        effect2.f |= EFFECT_RAN;
-      } catch (e) {
-        destroy_effect(effect2);
-        throw e;
-      }
-    } else if (fn !== null) {
-      schedule_effect(effect2);
-    }
-    var inert = sync && effect2.deps === null && effect2.first === null && effect2.nodes_start === null && effect2.teardown === null && (effect2.f & (EFFECT_HAS_DERIVED | BOUNDARY_EFFECT)) === 0;
-    if (!inert && !is_root && push2) {
-      if (parent_effect !== null) {
-        push_effect(effect2, parent_effect);
-      }
-      if (active_reaction !== null && (active_reaction.f & DERIVED) !== 0) {
-        var derived2 = (
-          /** @type {Derived} */
-          active_reaction
-        );
-        (derived2.effects ?? (derived2.effects = [])).push(effect2);
-      }
-    }
-    return effect2;
-  }
-  function teardown(fn) {
-    const effect2 = create_effect(RENDER_EFFECT, null, false);
-    set_signal_status(effect2, CLEAN);
-    effect2.teardown = fn;
-    return effect2;
-  }
-  function component_root(fn) {
-    const effect2 = create_effect(ROOT_EFFECT, fn, true);
-    return (options = {}) => {
-      return new Promise((fulfil) => {
-        if (options.outro) {
-          pause_effect(effect2, () => {
-            destroy_effect(effect2);
-            fulfil(void 0);
-          });
-        } else {
-          destroy_effect(effect2);
-          fulfil(void 0);
-        }
-      });
-    };
-  }
-  function effect(fn) {
-    return create_effect(EFFECT, fn, false);
-  }
-  function template_effect(fn, thunks = [], d = derived) {
-    const deriveds = thunks.map(d);
-    const effect2 = () => fn(...deriveds.map(get));
-    {
-      define_property(effect2, "name", {
-        value: "{expression}"
-      });
-    }
-    return block(effect2);
-  }
-  function block(fn, flags = 0) {
-    return create_effect(RENDER_EFFECT | BLOCK_EFFECT | flags, fn, true);
-  }
-  function branch(fn, push2 = true) {
-    return create_effect(RENDER_EFFECT | BRANCH_EFFECT, fn, true, push2);
-  }
-  function execute_effect_teardown(effect2) {
-    var teardown2 = effect2.teardown;
-    if (teardown2 !== null) {
-      const previous_reaction = active_reaction;
-      set_active_reaction(null);
-      try {
-        teardown2.call(null);
-      } finally {
-        set_active_reaction(previous_reaction);
-      }
-    }
-  }
-  function destroy_effect_children(signal, remove_dom = false) {
-    var effect2 = signal.first;
-    signal.first = signal.last = null;
-    while (effect2 !== null) {
-      var next = effect2.next;
-      destroy_effect(effect2, remove_dom);
-      effect2 = next;
-    }
-  }
-  function destroy_block_effect_children(signal) {
-    var effect2 = signal.first;
-    while (effect2 !== null) {
-      var next = effect2.next;
-      if ((effect2.f & BRANCH_EFFECT) === 0) {
-        destroy_effect(effect2);
-      }
-      effect2 = next;
-    }
-  }
-  function destroy_effect(effect2, remove_dom = true) {
-    var removed = false;
-    if ((remove_dom || (effect2.f & HEAD_EFFECT) !== 0) && effect2.nodes_start !== null) {
-      var node = effect2.nodes_start;
-      var end = effect2.nodes_end;
-      while (node !== null) {
-        var next = node === end ? null : (
-          /** @type {TemplateNode} */
-          /* @__PURE__ */ get_next_sibling(node)
-        );
-        node.remove();
-        node = next;
-      }
-      removed = true;
-    }
-    destroy_effect_children(effect2, remove_dom && !removed);
-    remove_reactions(effect2, 0);
-    set_signal_status(effect2, DESTROYED);
-    var transitions = effect2.transitions;
-    if (transitions !== null) {
-      for (const transition of transitions) {
-        transition.stop();
-      }
-    }
-    execute_effect_teardown(effect2);
-    var parent = effect2.parent;
-    if (parent !== null && parent.first !== null) {
-      unlink_effect(effect2);
-    }
-    {
-      effect2.component_function = null;
-    }
-    effect2.next = effect2.prev = effect2.teardown = effect2.ctx = effect2.deps = effect2.fn = effect2.nodes_start = effect2.nodes_end = null;
-  }
-  function unlink_effect(effect2) {
-    var parent = effect2.parent;
-    var prev = effect2.prev;
-    var next = effect2.next;
-    if (prev !== null) prev.next = next;
-    if (next !== null) next.prev = prev;
-    if (parent !== null) {
-      if (parent.first === effect2) parent.first = next;
-      if (parent.last === effect2) parent.last = prev;
-    }
-  }
-  function pause_effect(effect2, callback) {
-    var transitions = [];
-    pause_children(effect2, transitions, true);
-    run_out_transitions(transitions, () => {
-      destroy_effect(effect2);
-      if (callback) callback();
-    });
-  }
-  function run_out_transitions(transitions, fn) {
-    var remaining = transitions.length;
-    if (remaining > 0) {
-      var check = () => --remaining || fn();
-      for (var transition of transitions) {
-        transition.out(check);
-      }
-    } else {
-      fn();
-    }
-  }
-  function pause_children(effect2, transitions, local) {
-    if ((effect2.f & INERT) !== 0) return;
-    effect2.f ^= INERT;
-    if (effect2.transitions !== null) {
-      for (const transition of effect2.transitions) {
-        if (transition.is_global || local) {
-          transitions.push(transition);
-        }
-      }
-    }
-    var child2 = effect2.first;
-    while (child2 !== null) {
-      var sibling = child2.next;
-      var transparent = (child2.f & EFFECT_TRANSPARENT) !== 0 || (child2.f & BRANCH_EFFECT) !== 0;
-      pause_children(child2, transitions, transparent ? local : false);
-      child2 = sibling;
-    }
-  }
-  const boundaries = {};
-  const chrome_pattern = /at (?:.+ \()?(.+):(\d+):(\d+)\)?$/;
-  const firefox_pattern = /@(.+):(\d+):(\d+)$/;
-  function get_stack() {
-    const stack2 = new Error().stack;
-    if (!stack2) return null;
-    const entries = [];
-    for (const line of stack2.split("\n")) {
-      let match = chrome_pattern.exec(line) ?? firefox_pattern.exec(line);
-      if (match) {
-        entries.push({
-          file: match[1],
-          line: +match[2],
-          column: +match[3]
-        });
-      }
-    }
-    return entries;
-  }
-  function get_component() {
-    var _a;
-    const stack2 = (_a = get_stack()) == null ? void 0 : _a.slice(4);
-    if (!stack2) return null;
-    for (let i = 0; i < stack2.length; i++) {
-      const entry = stack2[i];
-      const modules = boundaries[entry.file];
-      if (!modules) {
-        if (i === 0) return null;
-        continue;
-      }
-      for (const module of modules) {
-        if (module.end == null) {
-          return null;
-        }
-        if (module.start.line < entry.line && module.end.line > entry.line) {
-          return module.component;
-        }
-      }
-    }
-    return null;
-  }
-  function mark_module_start() {
-    var _a, _b;
-    const start = (_a = get_stack()) == null ? void 0 : _a[2];
-    if (start) {
-      (boundaries[_b = start.file] ?? (boundaries[_b] = [])).push({
-        start,
-        // @ts-expect-error
-        end: null,
-        // @ts-expect-error we add the component at the end, since HMR will overwrite the function
-        component: null
-      });
-    }
-  }
-  function mark_module_end(component) {
-    var _a;
-    const end = (_a = get_stack()) == null ? void 0 : _a[2];
-    if (end) {
-      const boundaries_file = boundaries[end.file];
-      const boundary = boundaries_file[boundaries_file.length - 1];
-      boundary.end = end;
-      boundary.component = component;
-    }
-  }
-  function widen_ownership(from, to) {
-    if (to.owners === null) {
-      return;
-    }
-    while (from) {
-      if (from.owners === null) {
-        to.owners = null;
-        break;
-      }
-      for (const owner of from.owners) {
-        to.owners.add(owner);
-      }
-      from = from.parent;
-    }
-  }
-  function has_owner(metadata, component) {
-    if (metadata.owners === null) {
-      return true;
-    }
-    return metadata.owners.has(component) || // This helps avoid false positives when using HMR, where the component function is replaced
-    FILENAME in component && [...metadata.owners].some(
-      (owner) => (
-        /** @type {any} */
-        owner[FILENAME] === component[FILENAME]
-      )
-    ) || metadata.parent !== null && has_owner(metadata.parent, component);
-  }
-  function get_owner(metadata) {
-    var _a;
-    return ((_a = metadata == null ? void 0 : metadata.owners) == null ? void 0 : _a.values().next().value) ?? get_owner(
-      /** @type {ProxyMetadata} */
-      metadata.parent
-    );
-  }
-  function check_ownership(metadata) {
-    const component = get_component();
-    if (component && !has_owner(metadata, component)) {
-      let original = get_owner(metadata);
-      if (original[FILENAME] !== component[FILENAME]) {
-        ownership_invalid_mutation(component[FILENAME], original[FILENAME]);
-      } else {
-        ownership_invalid_mutation();
-      }
-    }
-  }
-  let component_context = null;
-  function set_component_context(context) {
-    component_context = context;
-  }
-  let dev_current_component_function = null;
-  function set_dev_current_component_function(fn) {
-    dev_current_component_function = fn;
-  }
-  function push(props, runes = false, fn) {
-    component_context = {
-      p: component_context,
-      c: null,
-      e: null,
-      m: false,
-      s: props,
-      x: null,
-      l: null
-    };
-    {
-      component_context.function = fn;
-      dev_current_component_function = fn;
-    }
-  }
-  function pop(component) {
-    var _a;
-    const context_stack_item = component_context;
-    if (context_stack_item !== null) {
-      if (component !== void 0) {
-        context_stack_item.x = component;
-      }
-      const component_effects = context_stack_item.e;
-      if (component_effects !== null) {
-        var previous_effect = active_effect;
-        var previous_reaction = active_reaction;
-        context_stack_item.e = null;
-        try {
-          for (var i = 0; i < component_effects.length; i++) {
-            var component_effect = component_effects[i];
-            set_active_effect(component_effect.effect);
-            set_active_reaction(component_effect.reaction);
-            effect(component_effect.fn);
-          }
-        } finally {
-          set_active_effect(previous_effect);
-          set_active_reaction(previous_reaction);
-        }
-      }
-      component_context = context_stack_item.p;
-      {
-        dev_current_component_function = ((_a = context_stack_item.p) == null ? void 0 : _a.function) ?? null;
-      }
-      context_stack_item.m = true;
-    }
-    return component || /** @type {T} */
-    {};
-  }
-  function is_runes() {
-    return true;
-  }
-  const PASSIVE_EVENTS = ["touchstart", "touchmove"];
-  function is_passive_event(name) {
-    return PASSIVE_EVENTS.includes(name);
   }
   function add_locations(fn, filename, locations) {
     return (...args) => {
@@ -1653,10 +1520,8 @@ ${indent}in ${name}`).join("")}
         current_target.host || null;
         try {
           var delegated = current_target["__" + event_name];
-          if (delegated !== void 0 && (!/** @type {any} */
-          current_target.disabled || // DOM could've been updated already by the time this is reached, so we check this as well
-          // -> the target could not have been disabled because it emits the event in the first place
-          event.target === current_target)) {
+          if (delegated !== void 0 && !/** @type {any} */
+          current_target.disabled) {
             if (is_array(delegated)) {
               var [fn, ...data2] = delegated;
               fn.apply(current_target, [event, ...data2]);
@@ -1745,6 +1610,10 @@ ${indent}in ${name}`).join("")}
       dom
     );
   }
+  const PASSIVE_EVENTS = ["touchstart", "touchmove"];
+  function is_passive_event(name) {
+    return PASSIVE_EVENTS.includes(name);
+  }
   function mount(component, options) {
     return _mount(component, options);
   }
@@ -1771,7 +1640,7 @@ ${indent}in ${name}`).join("")}
     event_handle(array_from(all_registered_events));
     root_event_handles.add(event_handle);
     var component = void 0;
-    var unmount = component_root(() => {
+    var unmount = effect_root(() => {
       var anchor_node = anchor ?? target.appendChild(create_text());
       branch(() => {
         if (context) {
@@ -1806,6 +1675,7 @@ ${indent}in ${name}`).join("")}
           }
         }
         root_event_handles.delete(event_handle);
+        mounted_components.delete(component);
         if (anchor_node !== anchor) {
           (_a = anchor_node.parentNode) == null ? void 0 : _a.removeChild(anchor_node);
         }
@@ -1856,7 +1726,7 @@ ${indent}in ${name}`).join("")}
     if (setters) return setters;
     setters_cache.set(element.nodeName, setters = []);
     var descriptors;
-    var proto = element;
+    var proto = get_prototype_of(element);
     var element_proto = Element.prototype;
     while (element_proto !== proto) {
       descriptors = get_descriptors(proto);
@@ -1872,31 +1742,20 @@ ${indent}in ${name}`).join("")}
   function bind_window_size(type, set2) {
     listen(window, ["resize"], () => without_reactive_context(() => set2(window[type])));
   }
-  {
-    let throw_rune_error = function(rune) {
-      if (!(rune in globalThis)) {
-        let value;
-        Object.defineProperty(globalThis, rune, {
-          configurable: true,
-          // eslint-disable-next-line getter-return
-          get: () => {
-            if (value !== void 0) {
-              return value;
-            }
-            rune_outside_svelte(rune);
-          },
-          set: (v) => {
-            value = v;
-          }
-        });
+  function validate_prop_bindings($$props, bindable, exports2, component) {
+    var _a;
+    for (const key in $$props) {
+      var setter = (_a = get_descriptor($$props, key)) == null ? void 0 : _a.set;
+      var name = component.name;
+      if (setter) {
+        if (exports2.includes(key)) {
+          bind_invalid_export(component[FILENAME], key, name);
+        }
+        if (!bindable.includes(key)) {
+          bind_not_bindable(key, component[FILENAME], name);
+        }
       }
-    };
-    throw_rune_error("$state");
-    throw_rune_error("$effect");
-    throw_rune_error("$derived");
-    throw_rune_error("$inspect");
-    throw_rune_error("$props");
-    throw_rune_error("$bindable");
+    }
   }
   const PUBLIC_VERSION = "5";
   if (typeof window !== "undefined")
@@ -1907,6 +1766,7 @@ ${indent}in ${name}`).join("")}
   function Viz($$anchor, $$props) {
     check_target(new.target);
     push($$props, true, Viz);
+    validate_prop_bindings($$props, [], [], Viz);
     let width = state$1(500);
     let height = state$1(500);
     var svg = root();
@@ -1928,19 +1788,20 @@ ${indent}in ${name}`).join("")}
   mark_module_end(Viz);
   var data = {};
   var state = { radius: 50, stroke: 2, color: "#ffffff" };
-  let reactiveState = proxy({ ...state });
+  let reactiveState = state$1(proxy({}));
   function draw() {
-    reactiveState.data = data;
+    set(reactiveState, proxy({ ...state }, null, reactiveState));
+    get(reactiveState).data = data;
     mount(Viz, {
       target: document.body,
-      props: reactiveState
+      props: get(reactiveState)
       // Pass the reactive state to Svelte
     });
   }
   function update() {
     if (state.radius <= 0) throw new Error("Radius must be positive");
-    Object.assign(reactiveState, state);
-    reactiveState.data = data;
+    Object.assign(get(reactiveState), state);
+    get(reactiveState).data = data;
   }
   exports.data = data;
   exports.draw = draw;

--- a/template.js
+++ b/template.js
@@ -1,17 +1,1951 @@
-var template=function(y){"use strict";var bn=y=>{throw TypeError(y)};var Ht=(y,p,h)=>p.has(y)||bn("Cannot "+h);var O=(y,p,h)=>(Ht(y,p,"read from private field"),h?h.call(y):p.get(y)),Se=(y,p,h)=>p.has(y)?bn("Cannot add the same private member more than once"):p instanceof WeakSet?p.add(y):p.set(y,h);var U,K,G;const p=Symbol(),h=Symbol("filename"),En=!0;var ke="font-weight: bold",$e="font-weight: normal";function xn(e,n,t){console.warn(`%c[svelte] ownership_invalid_binding
-%c${e} passed a value to ${n} with \`bind:\`, but the value is owned by ${t}. Consider creating a binding between ${t} and ${e}`,ke,$e)}function Be(e,n){console.warn(`%c[svelte] ownership_invalid_mutation
-%c${e?`${e} mutated a value owned by ${n}. This is strongly discouraged. Consider passing values to child components with \`bind:\`, or use a callback instead`:"Mutating a value outside the component that created it is strongly discouraged. Consider passing values to child components with `bind:`, or use a callback instead"}`,ke,$e)}function Te(e){console.warn(`%c[svelte] state_proxy_equality_mismatch
-%cReactive \`$state(...)\` proxies and the values they proxy have different identities. Because of this, comparisons with \`${e}\` will produce unexpected results`,ke,$e)}var Ve=Array.isArray,Sn=Array.from,re=Object.defineProperty,Z=Object.getOwnPropertyDescriptor,kn=Object.getOwnPropertyDescriptors,$n=Object.prototype,Tn=Array.prototype,ve=Object.getPrototypeOf;const q=2,We=4,ie=8,Oe=16,B=32,he=64,se=128,pe=256,x=512,V=1024,j=2048,Ye=4096,oe=8192,On=16384,ze=1<<17,An=1<<18,Nn=1<<19,le=Symbol("$state"),W=Symbol("$state metadata"),Cn=Symbol("");function Dn(e){return e===this.v}function In(e,n,t){{const r=new Error(`bind_invalid_export
-Component ${e} has an export named \`${n}\` that a consumer component is trying to access using \`bind:${n}\`, which is disallowed. Instead, use \`bind:this\` (e.g. \`<${t} bind:this={component} />\`) and then access the property on the bound component instance (e.g. \`component.${n}\`)`);throw r.name="Svelte error",r}}function Rn(e,n,t){{const r=new Error(`bind_not_bindable
-A component is attempting to bind to a non-bindable property \`${e}\` belonging to ${n} (i.e. \`<${t} bind:${e}={...}>\`). To mark a property as bindable: \`let { ${e} = $bindable() } = $props()\``);throw r.name="Svelte error",r}}function Fn(e,n,t){{const r=new Error(`component_api_changed
-${e} called \`${n}\` on an instance of ${t}, which is no longer valid in Svelte 5. See https://svelte.dev/docs/svelte/v5-migration-guide#Components-are-no-longer-classes for more information`);throw r.name="Svelte error",r}}function Pn(e,n){{const t=new Error(`component_api_invalid_new
-Attempted to instantiate ${e} with \`new ${n}\`, which is no longer valid in Svelte 5. If this component is not under your control, set the \`compatibility.componentApi\` compiler option to \`4\` to keep it working. See https://svelte.dev/docs/svelte/v5-migration-guide#Components-are-no-longer-classes for more information`);throw t.name="Svelte error",t}}function Ln(){{const e=new Error(`derived_references_self
-A derived value cannot reference itself recursively`);throw e.name="Svelte error",e}}function Mn(){{const e=new Error(`effect_update_depth_exceeded
-Maximum update depth exceeded. This can happen when a reactive block or effect repeatedly sets a new value. Svelte limits the number of nested updates to prevent infinite loops`);throw e.name="Svelte error",e}}function qn(e){{const n=new Error(`rune_outside_svelte
-The \`${e}\` rune is only available inside \`.svelte\` and \`.svelte.js/ts\` files`);throw n.name="Svelte error",n}}function Bn(){{const e=new Error("state_descriptors_fixed\nProperty descriptors defined on `$state` objects must contain `value` and always be `enumerable`, `configurable` and `writable`.");throw e.name="Svelte error",e}}function Vn(){{const e=new Error("state_prototype_fixed\nCannot set prototype of `$state` object");throw e.name="Svelte error",e}}function Wn(){{const e=new Error("state_unsafe_local_read\nReading state that was created inside the same derived is forbidden. Consider using `untrack` to read locally created state");throw e.name="Svelte error",e}}function Yn(){{const e=new Error("state_unsafe_mutation\nUpdating state inside a derived or a template expression is forbidden. If the value should not be reactive, declare it without `$state`");throw e.name="Svelte error",e}}let zn=!1,J=new Set;function He(e){J=e}function D(e){return{f:0,v:e,reactions:null,equals:Dn,version:0}}function ue(e){return Hn(D(e))}function Hn(e){return m!==null&&m.f&q&&(N===null?lt([e]):N.push(e)),e}function k(e,n){return m!==null&&at()&&m.f&(q|Oe)&&(N===null||!N.includes(e))&&Yn(),Un(e,n)}function Un(e,n){if(!e.equals(n)&&(e.v=n,e.version=sn(),Ue(e,V),w!==null&&w.f&x&&!(w.f&B)&&(b!==null&&b.includes(e)?(A(w,V),Ee(w)):L===null?ut([e]):L.push(e)),J.size>0)){const r=Array.from(J);var t=Y;ye(!0);try{for(const i of r)i.f&x&&A(i,j),de(i)&&be(i)}finally{ye(t)}J.clear()}return n}function Ue(e,n){var t=e.reactions;if(t!==null)for(var r=t.length,i=0;i<r;i++){var s=t[i],l=s.f;if(!(l&V)){if(l&ze){J.add(s);continue}A(s,n),l&(x|se)&&(l&q?Ue(s,j):Ee(s))}}}function Ke(e){var n=e.children;if(n!==null){e.children=null;for(var t=0;t<n.length;t+=1){var r=n[t];r.f&q?Ne(r):ae(r)}}}let Ae=[];function Ge(e){var n,t=w;P(e.parent);{let r=J;He(new Set);try{Ae.includes(e)&&Ln(),Ae.push(e),Ke(e),n=on(e)}finally{P(t),He(r),Ae.pop()}}return n}function Ze(e){var n=Ge(e),t=(X||e.f&se)&&e.deps!==null?j:x;A(e,t),e.equals(n)||(e.v=n,e.version=sn())}function Ne(e){Ke(e),_e(e,0),A(e,oe),e.v=e.children=e.deps=e.ctx=e.reactions=null}function Kn(e,n){var t=n.last;t===null?n.last=n.first=e:(t.next=e,e.prev=t,n.last=e)}function Q(e,n,t,r=!0){for(var i=(e&he)!==0,s=w;s!==null&&s.f&ze;)s=s.parent;var l={ctx:E,deps:null,deriveds:null,nodes_start:null,nodes_end:null,f:e|V,first:null,fn:n,last:null,next:null,parent:i?null:s,prev:null,teardown:null,transitions:null,version:0};if(l.component_function=z,t){var u=Y;try{ye(!0),be(l),l.f|=On}catch(f){throw ae(l),f}finally{ye(u)}}else n!==null&&Ee(l);var _=t&&l.deps===null&&l.first===null&&l.nodes_start===null&&l.teardown===null&&(l.f&Nn)===0;if(!_&&!i&&r&&(s!==null&&Kn(l,s),m!==null&&m.f&q)){var g=m;(g.children??(g.children=[])).push(l)}return l}function Gn(e){const n=Q(ie,null,!1);return A(n,x),n.teardown=e,n}function Zn(e){const n=Q(he,e,!0);return()=>{ae(n)}}function jn(e){return Q(We,e,!1)}function Jn(e){return Q(ie,e,!0)}function Qn(e){return re(e,"name",{value:"{expression}"}),Xn(e)}function Xn(e,n=0){return Q(ie|Oe|n,e,!0)}function et(e,n=!0){return Q(ie|B,e,!0,n)}function je(e){var n=e.teardown;if(n!==null){const t=m;F(null);try{n.call(null)}finally{F(t)}}}function Je(e){var n=e.deriveds;if(n!==null){e.deriveds=null;for(var t=0;t<n.length;t+=1)Ne(n[t])}}function Qe(e,n=!1){var t=e.first;for(e.first=e.last=null;t!==null;){var r=t.next;ae(t,n),t=r}}function nt(e){for(var n=e.first;n!==null;){var t=n.next;n.f&B||ae(n),n=t}}function ae(e,n=!0){var t=!1;if((n||e.f&An)&&e.nodes_start!==null){for(var r=e.nodes_start,i=e.nodes_end;r!==null;){var s=r===i?null:mt(r);r.remove(),r=s}t=!0}Qe(e,n&&!t),Je(e),_e(e,0),A(e,oe);var l=e.transitions;if(l!==null)for(const _ of l)_.stop();je(e);var u=e.parent;u!==null&&u.first!==null&&Xe(e),e.component_function=null,e.next=e.prev=e.teardown=e.ctx=e.deps=e.parent=e.fn=e.nodes_start=e.nodes_end=null}function Xe(e){var n=e.parent,t=e.prev,r=e.next;t!==null&&(t.next=r),r!==null&&(r.prev=t),n!==null&&(n.first===e&&(n.first=r),n.last===e&&(n.last=t))}const fe={},tt=/at (?:.+ \()?(.+):(\d+):(\d+)\)?$/,rt=/@(.+):(\d+):(\d+)$/;function Ce(){const e=new Error().stack;if(!e)return null;const n=[];for(const t of e.split(`
-`)){let r=tt.exec(t)??rt.exec(t);r&&n.push({file:r[1],line:+r[2],column:+r[3]})}return n}function en(){var n;const e=(n=Ce())==null?void 0:n.slice(4);if(!e)return null;for(let t=0;t<e.length;t++){const r=e[t],i=fe[r.file];if(!i){if(t===0)return null;continue}for(const s of i){if(s.end==null)return null;if(s.start.line<r.line&&s.end.line>r.line)return s.component}}return null}const we=Symbol("ADD_OWNER");function it(){var n,t;const e=(n=Ce())==null?void 0:n[2];e&&(fe[t=e.file]??(fe[t]=[])).push({start:e,end:null,component:null})}function st(e){var t;const n=(t=Ce())==null?void 0:t[2];if(n){const r=fe[n.file],i=r[r.length-1];i.end=n,i.component=e}}function De(e,n,t=!1,r=!1){if(e&&!t){const i=z,s=e[W];if(s&&!Re(s,i)){let l=Fe(s);n[h]!==i[h]&&!r&&xn(i[h],n[h],l[h])}}Ie(e,n,new Set)}function nn(e,n){if(n.owners!==null)for(;e;){if(e.owners===null){n.owners=null;break}for(const t of e.owners)n.owners.add(t);e=e.parent}}function Ie(e,n,t){const r=e==null?void 0:e[W];if(r)"owners"in r&&r.owners!=null&&r.owners.add(n);else if(e&&typeof e=="object"){if(t.has(e))return;if(t.add(e),we in e&&e[we])Jn(()=>{e[we](n)});else{var i=ve(e);if(i===Object.prototype)for(const s in e)Ie(e[s],n,t);else if(i===Array.prototype)for(let s=0;s<e.length;s+=1)Ie(e[s],n,t)}}}function Re(e,n){return e.owners===null?!0:e.owners.has(n)||e.parent!==null&&Re(e.parent,n)}function Fe(e){var n;return((n=e==null?void 0:e.owners)==null?void 0:n.values().next().value)??Fe(e.parent)}function ot(e){const n=en();if(n&&!Re(e,n)){let t=Fe(e);t[h]!==n[h]?Be(n[h],t[h]):Be()}}const tn=new WeakSet;let ge=!1,Y=!1;function ye(e){Y=e}let Pe=[],ce=0,me=[],m=null;function F(e){m=e}let w=null;function P(e){w=e}let N=null;function lt(e){N=e}let b=null,$=0,L=null;function ut(e){L=e}let rn=0,X=!1,E=null,z=null;function sn(){return++rn}function at(){return!zn}function de(e){var l,u;var n=e.f;if(n&V)return!0;if(n&j){var t=e.deps,r=(n&se)!==0;if(t!==null){var i;if(n&pe){for(i=0;i<t.length;i++)((l=t[i]).reactions??(l.reactions=[])).push(e);e.f^=pe}for(i=0;i<t.length;i++){var s=t[i];if(de(s)&&Ze(s),r&&w!==null&&!X&&!((u=s==null?void 0:s.reactions)!=null&&u.includes(e))&&(s.reactions??(s.reactions=[])).push(e),s.version>e.version)return!0}}r||A(e,x)}return!1}function ft(e,n,t){var g,f;if(tn.has(e)||t===null)throw e;const r=[],i=(g=n.fn)==null?void 0:g.name;i&&r.push(i);let s=t;for(;s!==null;){{var l=(f=s.function)==null?void 0:f[h];if(l){const o=l.split("/").pop();r.push(o)}}s=s.p}const u=/Firefox/.test(navigator.userAgent)?"  ":"	";re(e,"message",{value:e.message+`
-${r.map(o=>`
-${u}in ${o}`).join("")}
-`});const _=e.stack;if(_){const o=_.split(`
-`),a=[];for(let c=0;c<o.length;c++){const d=o[c];d.includes("svelte/src/internal")||a.push(d)}re(e,"stack",{value:e.stack+a.join(`
-`)})}throw tn.add(e),e}function on(e){var a;var n=b,t=$,r=L,i=m,s=X,l=N,u=E,_=e.f;b=null,$=0,L=null,m=_&(B|he)?null:e,X=!Y&&(_&se)!==0,N=null,E=e.ctx;try{var g=(0,e.fn)(),f=e.deps;if(b!==null){var o;if(_e(e,$),f!==null&&$>0)for(f.length=$+b.length,o=0;o<b.length;o++)f[$+o]=b[o];else e.deps=f=b;if(!X)for(o=$;o<f.length;o++)((a=f[o]).reactions??(a.reactions=[])).push(e)}else f!==null&&$<f.length&&(_e(e,$),f.length=$);return g}finally{b=n,$=t,L=r,m=i,X=s,N=l,E=u}}function ct(e,n){let t=n.reactions;if(t!==null){var r=t.indexOf(e);if(r!==-1){var i=t.length-1;i===0?t=n.reactions=null:(t[r]=t[i],t.pop())}}t===null&&n.f&q&&(b===null||!b.includes(n))&&(A(n,j),n.f&(se|pe)||(n.f^=pe),_e(n,0))}function _e(e,n){var t=e.deps;if(t!==null)for(var r=n;r<t.length;r++)ct(e,t[r])}function be(e){var n=e.f;if(!(n&oe)){A(e,x);var t=w,r=E;w=e;{var i=z;z=e.component_function}try{n&Oe?nt(e):Qe(e),Je(e),je(e);var s=on(e);e.teardown=typeof s=="function"?s:null,e.version=rn,En&&me.push(e)}catch(l){ft(l,e,r)}finally{w=t,z=i}}}function dt(){if(ce>1e3){ce=0;try{Mn()}catch(e){throw re(e,"stack",{value:""}),console.error("Last ten effects were: ",me.slice(-10).map(n=>n.fn)),me=[],e}}ce++}function _t(e){var n=e.length;if(n!==0){dt();var t=Y;Y=!0;try{for(var r=0;r<n;r++){var i=e[r];i.f&x||(i.f^=x);var s=[];ln(i,s),vt(s)}}finally{Y=t}}}function vt(e){var n=e.length;if(n!==0)for(var t=0;t<n;t++){var r=e[t];!(r.f&(oe|Ye))&&de(r)&&(be(r),r.deps===null&&r.first===null&&r.nodes_start===null&&(r.teardown===null?Xe(r):r.fn=null))}}function ht(){if(ge=!1,ce>1001)return;const e=Pe;Pe=[],_t(e),ge||(ce=0,me=[])}function Ee(e){ge||(ge=!0,queueMicrotask(ht));for(var n=e;n.parent!==null;){n=n.parent;var t=n.f;if(t&(he|B)){if(!(t&x))return;n.f^=x}}Pe.push(n)}function ln(e,n){var t=e.first,r=[];e:for(;t!==null;){var i=t.f,s=(i&B)!==0,l=s&&(i&x)!==0;if(!l&&!(i&Ye))if(i&ie){s?t.f^=x:de(t)&&be(t);var u=t.first;if(u!==null){t=u;continue}}else i&We&&r.push(t);var _=t.next;if(_===null){let o=t.parent;for(;o!==null;){if(e===o)break e;var g=o.next;if(g!==null){t=g;continue e}o=o.parent}}t=_}for(var f=0;f<r.length;f++)u=r[f],n.push(u),ln(u,n)}function S(e){var u;var n=e.f,t=(n&q)!==0;if(t&&n&oe){var r=Ge(e);return Ne(e),r}if(m!==null){N!==null&&N.includes(e)&&Wn();var i=m.deps;b===null&&i!==null&&i[$]===e?$++:b===null?b=[e]:b.push(e),L!==null&&w!==null&&w.f&x&&!(w.f&B)&&L.includes(e)&&(A(w,V),Ee(w))}else if(t&&e.deps===null){var s=e,l=s.parent;l!==null&&!((u=l.deriveds)!=null&&u.includes(s))&&(l.deriveds??(l.deriveds=[])).push(s)}return t&&(s=e,de(s)&&Ze(s)),e.v}const pt=~(V|j|x);function A(e,n){e.f=e.f&pt|n}function un(e,n=!1,t){E={p:E,c:null,e:null,m:!1,s:e,x:null,l:null},E.function=t,z=t}function an(e){var l;const n=E;if(n!==null){e!==void 0&&(n.x=e);const u=n.e;if(u!==null){var t=w,r=m;n.e=null;try{for(var i=0;i<u.length;i++){var s=u[i];P(s.effect),F(s.reaction),jn(s.fn)}}finally{P(t),F(r)}}E=n.p,z=((l=n.p)==null?void 0:l.function)??null,n.m=!0}return e||{}}{let e=function(n){if(!(n in globalThis)){let t;Object.defineProperty(globalThis,n,{configurable:!0,get:()=>{if(t!==void 0)return t;qn(n)},set:r=>{t=r}})}};e("$state"),e("$effect"),e("$derived"),e("$inspect"),e("$props"),e("$bindable")}function C(e,n=null,t){var _,g;if(typeof e!="object"||e===null||le in e)return e;const r=ve(e);if(r!==$n&&r!==Tn)return e;var i=new Map,s=Ve(e),l=D(0);s&&i.set("length",D(e.length));var u;if(u={parent:n,owners:null},t){const f=(g=(_=t.v)==null?void 0:_[W])==null?void 0:g.owners;u.owners=f?new Set(f):null}else u.owners=n===null?E!==null?new Set([E.function]):null:new Set;return new Proxy(e,{defineProperty(f,o,a){(!("value"in a)||a.configurable===!1||a.enumerable===!1||a.writable===!1)&&Bn();var c=i.get(o);return c===void 0?(c=D(a.value),i.set(o,c)):k(c,C(a.value,u)),!0},deleteProperty(f,o){var a=i.get(o);if(a===void 0)o in f&&i.set(o,D(p));else{if(s&&typeof o=="string"){var c=i.get("length"),d=Number(o);Number.isInteger(d)&&d<c.v&&k(c,d)}k(a,p),fn(l)}return!0},get(f,o,a){var I;if(o===W)return u;if(o===le)return e;var c=i.get(o),d=o in f;if(c===void 0&&(!d||(I=Z(f,o))!=null&&I.writable)&&(c=D(C(d?f[o]:p,u)),i.set(o,c)),c!==void 0){var v=S(c);{var T=v==null?void 0:v[W];T&&(T==null?void 0:T.parent)!==u&&nn(u,T)}return v===p?void 0:v}return Reflect.get(f,o,a)},getOwnPropertyDescriptor(f,o){var a=Reflect.getOwnPropertyDescriptor(f,o);if(a&&"value"in a){var c=i.get(o);c&&(a.value=S(c))}else if(a===void 0){var d=i.get(o),v=d==null?void 0:d.v;if(d!==void 0&&v!==p)return{enumerable:!0,configurable:!0,value:v,writable:!0}}return a},has(f,o){var v;if(o===W||o===le)return!0;var a=i.get(o),c=a!==void 0&&a.v!==p||Reflect.has(f,o);if(a!==void 0||w!==null&&(!c||(v=Z(f,o))!=null&&v.writable)){a===void 0&&(a=D(c?C(f[o],u):p),i.set(o,a));var d=S(a);if(d===p)return!1}return c},set(f,o,a,c){var mn;var d=i.get(o),v=o in f;if(s&&o==="length")for(var T=a;T<d.v;T+=1){var I=i.get(T+"");I!==void 0?k(I,p):T in f&&(I=D(p),i.set(T+"",I))}d===void 0?(!v||(mn=Z(f,o))!=null&&mn.writable)&&(d=D(void 0),k(d,C(a,u)),i.set(o,d)):(v=d.v!==p,k(d,C(a,u)));{var M=a==null?void 0:a[W];M&&(M==null?void 0:M.parent)!==u&&nn(u,M),ot(u)}var R=Reflect.getOwnPropertyDescriptor(f,o);if(R!=null&&R.set&&R.set.call(c,a),!v){if(s&&typeof o=="string"){var yn=i.get("length"),qe=Number(o);Number.isInteger(qe)&&qe>=yn.v&&k(yn,qe+1)}fn(l)}return!0},ownKeys(f){S(l);var o=Reflect.ownKeys(f).filter(d=>{var v=i.get(d);return v===void 0||v.v!==p});for(var[a,c]of i)c.v!==p&&!(a in f)&&o.push(a);return o},setPrototypeOf(){Vn()}})}function fn(e,n=1){k(e,e.v+n)}function ee(e){return e!==null&&typeof e=="object"&&le in e?e[le]:e}function wt(){const e=Array.prototype,n=Array.__svelte_cleanup;n&&n();const{indexOf:t,lastIndexOf:r,includes:i}=e;e.indexOf=function(s,l){const u=t.call(this,s,l);return u===-1&&t.call(ee(this),ee(s),l)!==-1&&Te("array.indexOf(...)"),u},e.lastIndexOf=function(s,l){const u=r.call(this,s,l??this.length-1);return u===-1&&r.call(ee(this),ee(s),l??this.length-1)!==-1&&Te("array.lastIndexOf(...)"),u},e.includes=function(s,l){const u=i.call(this,s,l);return u||i.call(ee(this),ee(s),l)&&Te("array.includes(...)"),u},Array.__svelte_cleanup=()=>{e.indexOf=t,e.lastIndexOf=r,e.includes=i}}var cn,dn,_n;function gt(){if(cn===void 0){cn=window;var e=Element.prototype,n=Node.prototype;dn=Z(n,"firstChild").get,_n=Z(n,"nextSibling").get,e.__click=void 0,e.__className="",e.__attributes=null,e.__styles=null,e.__e=void 0,Text.prototype.__t=void 0,e.__svelte_meta=null,wt()}}function yt(e=""){return document.createTextNode(e)}function Le(e){return dn.call(e)}function mt(e){return _n.call(e)}function bt(e,n){return Le(e)}function Et(e,n,t){return(...r)=>{const i=e(...r);var s=i.nodeType===11?i.firstChild:i;return vn(s,n,t),i}}function xt(e,n,t){e.__svelte_meta={loc:{file:n,line:t[0],column:t[1]}},t[2]&&vn(e.firstChild,n,t[2])}function vn(e,n,t){for(var r=0;e&&r<t.length;)e.nodeType===1&&xt(e,n,t[r++]),e=e.nextSibling}function St(e,n,t,r=!0){r&&t();for(var i of n)e.addEventListener(i,t);Gn(()=>{for(var s of n)e.removeEventListener(s,t)})}function kt(e){var n=m,t=w;F(null),P(null);try{return e()}finally{F(n),P(t)}}const $t=new Set,hn=new Set;function xe(e){var M;var n=this,t=n.ownerDocument,r=e.type,i=((M=e.composedPath)==null?void 0:M.call(e))||[],s=i[0]||e.target,l=0,u=e.__root;if(u){var _=i.indexOf(u);if(_!==-1&&(n===document||n===window)){e.__root=n;return}var g=i.indexOf(n);if(g===-1)return;_<=g&&(l=_)}if(s=i[l]||e.target,s!==n){re(e,"currentTarget",{configurable:!0,get(){return s||t}});var f=m,o=w;F(null),P(null);try{for(var a,c=[];s!==null;){var d=s.assignedSlot||s.parentNode||s.host||null;try{var v=s["__"+r];if(v!==void 0&&!s.disabled)if(Ve(v)){var[T,...I]=v;T.apply(s,[e,...I])}else v.call(s,e)}catch(R){a?c.push(R):a=R}if(e.cancelBubble||d===n||d===null)break;s=d}if(a){for(let R of c)queueMicrotask(()=>{throw R});throw a}}finally{e.__root=n,delete e.currentTarget,F(f),P(o)}}}function Tt(e){var n=document.createElement("template");return n.innerHTML=e,n.content}function Ot(e,n){var t=w;t.nodes_start===null&&(t.nodes_start=e,t.nodes_end=n)}function At(e,n,t="svg"){var r=!e.startsWith("<!>"),i=`<${t}>${r?e:"<!>"+e}</${t}>`,s;return()=>{if(!s){var l=Tt(i),u=Le(l);s=Le(u)}var _=s.cloneNode(!0);return Ot(_,_),_}}function Nt(e,n){e!==null&&e.before(n)}const Ct=["touchstart","touchmove"];function Dt(e){return Ct.includes(e)}function It(e,n){return Rt(e,n)}const ne=new Map;function Rt(e,{target:n,anchor:t,props:r={},events:i,context:s,intro:l=!0}){gt();var u=new Set,_=o=>{for(var a=0;a<o.length;a++){var c=o[a];if(!u.has(c)){u.add(c);var d=Dt(c);n.addEventListener(c,xe,{passive:d});var v=ne.get(c);v===void 0?(document.addEventListener(c,xe,{passive:d}),ne.set(c,1)):ne.set(c,v+1)}}};_(Sn($t)),hn.add(_);var g=void 0,f=Zn(()=>{var o=t??n.appendChild(yt());return et(()=>{if(s){un({});var a=E;a.c=s}i&&(r.$$events=i),g=e(o,r)||{},s&&an()}),()=>{var d;for(var a of u){n.removeEventListener(a,xe);var c=ne.get(a);--c===0?(document.removeEventListener(a,xe),ne.delete(a)):ne.set(a,c)}hn.delete(_),pn.delete(g),o!==t&&((d=o.parentNode)==null||d.removeChild(o))}});return pn.set(g,f),g}let pn=new WeakMap;function Ft(e){e&&Pn(e[h]??"a component",e.name)}function Pt(){const e=E==null?void 0:E.function;function n(t){var i;const r=((i=en())==null?void 0:i[h])??"Something";Fn(r,t,e[h])}return{$destroy:()=>n("$destroy()"),$on:()=>n("$on(...)"),$set:()=>n("$set(...)")}}function H(e,n,t,r){var i=e.__attributes??(e.__attributes={});i[n]!==(i[n]=t)&&(n==="style"&&"__styles"in e&&(e.__styles={}),n==="loading"&&(e[Cn]=t),t==null?e.removeAttribute(n):typeof t!="string"&&Lt(e).includes(n)?e[n]=t:e.setAttribute(n,t))}var wn=new Map;function Lt(e){var n=wn.get(e.nodeName);if(n)return n;wn.set(e.nodeName,n=[]);for(var t,r=ve(e),i=Element.prototype;i!==r;){t=kn(r);for(var s in t)t[s].set&&n.push(s);r=ve(r)}return n}function gn(e,n){St(window,["resize"],()=>kt(()=>n(window[e])))}function Mt(e,n,t,r){var l;for(const u in e){var i=(l=Z(e,u))==null?void 0:l.set,s=r.name;i&&(t.includes(u)&&In(r[h],u,s),n.includes(u)||Rn(u,r[h],s))}}const qt="5";typeof window<"u"&&(window.__svelte||(window.__svelte={v:new Set})).v.add(qt),it(),te[h]="src/Viz.svelte";var Bt=Et(At('<svg><circle stroke="black"></circle></svg>'),te[h],[[10,0,[[11,2]]]]);function te(e,n){Ft(new.target),un(n,!0,te),Mt(n,[],[],te);let t=ue(500),r=ue(500);var i=Bt(),s=bt(i);return Qn(()=>{H(i,"width",S(t)),H(i,"height",S(r)),H(s,"cx",S(t)/2),H(s,"cy",S(r)/2),H(s,"r",n.radius),H(s,"fill",n.color),H(s,"stroke-width",n.stroke)}),gn("innerWidth",l=>k(t,C(l,null,t))),gn("innerHeight",l=>k(r,C(l,null,r))),Nt(e,i),an({...Pt()})}st(te);var Vt={};class Wt{constructor(n,t,r){Se(this,U,ue());Se(this,K,ue());Se(this,G,ue());this.radius=n,this.stroke=t,this.color=r}get radius(){return S(O(this,U))}set radius(n){k(O(this,U),C(n,null,O(this,U)))}get stroke(){return S(O(this,K))}set stroke(n){k(O(this,K),C(n,null,O(this,K)))}get color(){return S(O(this,G))}set color(n){k(O(this,G),C(n,null,O(this,G)))}[we](n){De(S(O(this,U)),n,!1),De(S(O(this,K)),n,!1),De(S(O(this,G)),n,!1)}}U=new WeakMap,K=new WeakMap,G=new WeakMap;var Me=new Wt(10,1,"#FF0000");function Yt(){It(te,{target:document.body,props:Me})}function zt(){if(Me.radius<=0)throw new Error("Radius must be positive")}return y.data=Vt,y.draw=Yt,y.state=Me,y.update=zt,Object.defineProperty(y,Symbol.toStringTag,{value:"Module"}),y}({});
+var template = function(exports) {
+  "use strict";
+  const UNINITIALIZED = Symbol();
+  const FILENAME = Symbol("filename");
+  const DEV = true;
+  const DERIVED = 1 << 1;
+  const EFFECT = 1 << 2;
+  const RENDER_EFFECT = 1 << 3;
+  const BLOCK_EFFECT = 1 << 4;
+  const BRANCH_EFFECT = 1 << 5;
+  const ROOT_EFFECT = 1 << 6;
+  const BOUNDARY_EFFECT = 1 << 7;
+  const UNOWNED = 1 << 8;
+  const DISCONNECTED = 1 << 9;
+  const CLEAN = 1 << 10;
+  const DIRTY = 1 << 11;
+  const MAYBE_DIRTY = 1 << 12;
+  const INERT = 1 << 13;
+  const DESTROYED = 1 << 14;
+  const EFFECT_RAN = 1 << 15;
+  const EFFECT_TRANSPARENT = 1 << 16;
+  const INSPECT_EFFECT = 1 << 18;
+  const HEAD_EFFECT = 1 << 19;
+  const EFFECT_HAS_DERIVED = 1 << 20;
+  const STATE_SYMBOL = Symbol("$state");
+  const STATE_SYMBOL_METADATA = Symbol("$state metadata");
+  const LOADING_ATTR_SYMBOL = Symbol("");
+  var is_array = Array.isArray;
+  var index_of = Array.prototype.indexOf;
+  var array_from = Array.from;
+  var define_property = Object.defineProperty;
+  var get_descriptor = Object.getOwnPropertyDescriptor;
+  var get_descriptors = Object.getOwnPropertyDescriptors;
+  var object_prototype = Object.prototype;
+  var array_prototype = Array.prototype;
+  var get_prototype_of = Object.getPrototypeOf;
+  function equals(value) {
+    return value === this.v;
+  }
+  function component_api_changed(parent, method, component) {
+    {
+      const error = new Error(`component_api_changed
+${parent} called \`${method}\` on an instance of ${component}, which is no longer valid in Svelte 5
+https://svelte.dev/e/component_api_changed`);
+      error.name = "Svelte error";
+      throw error;
+    }
+  }
+  function component_api_invalid_new(component, name) {
+    {
+      const error = new Error(`component_api_invalid_new
+Attempted to instantiate ${component} with \`new ${name}\`, which is no longer valid in Svelte 5. If this component is not under your control, set the \`compatibility.componentApi\` compiler option to \`4\` to keep it working.
+https://svelte.dev/e/component_api_invalid_new`);
+      error.name = "Svelte error";
+      throw error;
+    }
+  }
+  function derived_references_self() {
+    {
+      const error = new Error(`derived_references_self
+A derived value cannot reference itself recursively
+https://svelte.dev/e/derived_references_self`);
+      error.name = "Svelte error";
+      throw error;
+    }
+  }
+  function effect_update_depth_exceeded() {
+    {
+      const error = new Error(`effect_update_depth_exceeded
+Maximum update depth exceeded. This can happen when a reactive block or effect repeatedly sets a new value. Svelte limits the number of nested updates to prevent infinite loops
+https://svelte.dev/e/effect_update_depth_exceeded`);
+      error.name = "Svelte error";
+      throw error;
+    }
+  }
+  function rune_outside_svelte(rune) {
+    {
+      const error = new Error(`rune_outside_svelte
+The \`${rune}\` rune is only available inside \`.svelte\` and \`.svelte.js/ts\` files
+https://svelte.dev/e/rune_outside_svelte`);
+      error.name = "Svelte error";
+      throw error;
+    }
+  }
+  function state_descriptors_fixed() {
+    {
+      const error = new Error(`state_descriptors_fixed
+Property descriptors defined on \`$state\` objects must contain \`value\` and always be \`enumerable\`, \`configurable\` and \`writable\`.
+https://svelte.dev/e/state_descriptors_fixed`);
+      error.name = "Svelte error";
+      throw error;
+    }
+  }
+  function state_prototype_fixed() {
+    {
+      const error = new Error(`state_prototype_fixed
+Cannot set prototype of \`$state\` object
+https://svelte.dev/e/state_prototype_fixed`);
+      error.name = "Svelte error";
+      throw error;
+    }
+  }
+  function state_unsafe_local_read() {
+    {
+      const error = new Error(`state_unsafe_local_read
+Reading state that was created inside the same derived is forbidden. Consider using \`untrack\` to read locally created state
+https://svelte.dev/e/state_unsafe_local_read`);
+      error.name = "Svelte error";
+      throw error;
+    }
+  }
+  function state_unsafe_mutation() {
+    {
+      const error = new Error(`state_unsafe_mutation
+Updating state inside a derived or a template expression is forbidden. If the value should not be reactive, declare it without \`$state\`
+https://svelte.dev/e/state_unsafe_mutation`);
+      error.name = "Svelte error";
+      throw error;
+    }
+  }
+  let tracing_mode_flag = false;
+  let inspect_effects = /* @__PURE__ */ new Set();
+  function set_inspect_effects(v) {
+    inspect_effects = v;
+  }
+  function source(v, stack2) {
+    var signal = {
+      f: 0,
+      // TODO ideally we could skip this altogether, but it causes type errors
+      v,
+      reactions: null,
+      equals,
+      rv: 0,
+      wv: 0
+    };
+    return signal;
+  }
+  function state$1(v) {
+    return /* @__PURE__ */ push_derived_source(source(v));
+  }
+  // @__NO_SIDE_EFFECTS__
+  function push_derived_source(source2) {
+    if (active_reaction !== null && !untracking && (active_reaction.f & DERIVED) !== 0) {
+      if (derived_sources === null) {
+        set_derived_sources([source2]);
+      } else {
+        derived_sources.push(source2);
+      }
+    }
+    return source2;
+  }
+  function set(source2, value) {
+    if (active_reaction !== null && !untracking && is_runes() && (active_reaction.f & (DERIVED | BLOCK_EFFECT)) !== 0 && // If the source was created locally within the current derived, then
+    // we allow the mutation.
+    (derived_sources === null || !derived_sources.includes(source2))) {
+      state_unsafe_mutation();
+    }
+    return internal_set(source2, value);
+  }
+  function internal_set(source2, value) {
+    if (!source2.equals(value)) {
+      source2.v;
+      source2.v = value;
+      source2.wv = increment_write_version();
+      mark_reactions(source2, DIRTY);
+      if (active_effect !== null && (active_effect.f & CLEAN) !== 0 && (active_effect.f & (BRANCH_EFFECT | ROOT_EFFECT)) === 0) {
+        if (untracked_writes === null) {
+          set_untracked_writes([source2]);
+        } else {
+          untracked_writes.push(source2);
+        }
+      }
+      if (inspect_effects.size > 0) {
+        const inspects = Array.from(inspect_effects);
+        for (const effect2 of inspects) {
+          if ((effect2.f & CLEAN) !== 0) {
+            set_signal_status(effect2, MAYBE_DIRTY);
+          }
+          if (check_dirtiness(effect2)) {
+            update_effect(effect2);
+          }
+        }
+        inspect_effects.clear();
+      }
+    }
+    return value;
+  }
+  function mark_reactions(signal, status) {
+    var reactions = signal.reactions;
+    if (reactions === null) return;
+    var length = reactions.length;
+    for (var i = 0; i < length; i++) {
+      var reaction = reactions[i];
+      var flags = reaction.f;
+      if ((flags & DIRTY) !== 0) continue;
+      if ((flags & INSPECT_EFFECT) !== 0) {
+        inspect_effects.add(reaction);
+        continue;
+      }
+      set_signal_status(reaction, status);
+      if ((flags & (CLEAN | UNOWNED)) !== 0) {
+        if ((flags & DERIVED) !== 0) {
+          mark_reactions(
+            /** @type {Derived} */
+            reaction,
+            MAYBE_DIRTY
+          );
+        } else {
+          schedule_effect(
+            /** @type {Effect} */
+            reaction
+          );
+        }
+      }
+    }
+  }
+  // @__NO_SIDE_EFFECTS__
+  function derived(fn) {
+    var flags = DERIVED | DIRTY;
+    var parent_derived = active_reaction !== null && (active_reaction.f & DERIVED) !== 0 ? (
+      /** @type {Derived} */
+      active_reaction
+    ) : null;
+    if (active_effect === null || parent_derived !== null && (parent_derived.f & UNOWNED) !== 0) {
+      flags |= UNOWNED;
+    } else {
+      active_effect.f |= EFFECT_HAS_DERIVED;
+    }
+    const signal = {
+      ctx: component_context,
+      deps: null,
+      effects: null,
+      equals,
+      f: flags,
+      fn,
+      reactions: null,
+      rv: 0,
+      v: (
+        /** @type {V} */
+        null
+      ),
+      wv: 0,
+      parent: parent_derived ?? active_effect
+    };
+    return signal;
+  }
+  function destroy_derived_effects(derived2) {
+    var effects = derived2.effects;
+    if (effects !== null) {
+      derived2.effects = null;
+      for (var i = 0; i < effects.length; i += 1) {
+        destroy_effect(
+          /** @type {Effect} */
+          effects[i]
+        );
+      }
+    }
+  }
+  let stack = [];
+  function get_derived_parent_effect(derived2) {
+    var parent = derived2.parent;
+    while (parent !== null) {
+      if ((parent.f & DERIVED) === 0) {
+        return (
+          /** @type {Effect} */
+          parent
+        );
+      }
+      parent = parent.parent;
+    }
+    return null;
+  }
+  function execute_derived(derived2) {
+    var value;
+    var prev_active_effect = active_effect;
+    set_active_effect(get_derived_parent_effect(derived2));
+    {
+      let prev_inspect_effects = inspect_effects;
+      set_inspect_effects(/* @__PURE__ */ new Set());
+      try {
+        if (stack.includes(derived2)) {
+          derived_references_self();
+        }
+        stack.push(derived2);
+        destroy_derived_effects(derived2);
+        value = update_reaction(derived2);
+      } finally {
+        set_active_effect(prev_active_effect);
+        set_inspect_effects(prev_inspect_effects);
+        stack.pop();
+      }
+    }
+    return value;
+  }
+  function update_derived(derived2) {
+    var value = execute_derived(derived2);
+    var status = (skip_reaction || (derived2.f & UNOWNED) !== 0) && derived2.deps !== null ? MAYBE_DIRTY : CLEAN;
+    set_signal_status(derived2, status);
+    if (!derived2.equals(value)) {
+      derived2.v = value;
+      derived2.wv = increment_write_version();
+    }
+  }
+  var bold = "font-weight: bold";
+  var normal = "font-weight: normal";
+  function ownership_invalid_mutation(component, owner) {
+    {
+      console.warn(`%c[svelte] ownership_invalid_mutation
+%c${component ? `${component} mutated a value owned by ${owner}. This is strongly discouraged. Consider passing values to child components with \`bind:\`, or use a callback instead` : "Mutating a value outside the component that created it is strongly discouraged. Consider passing values to child components with `bind:`, or use a callback instead"}
+https://svelte.dev/e/ownership_invalid_mutation`, bold, normal);
+    }
+  }
+  function state_proxy_equality_mismatch(operator) {
+    {
+      console.warn(`%c[svelte] state_proxy_equality_mismatch
+%cReactive \`$state(...)\` proxies and the values they proxy have different identities. Because of this, comparisons with \`${operator}\` will produce unexpected results
+https://svelte.dev/e/state_proxy_equality_mismatch`, bold, normal);
+    }
+  }
+  function proxy(value, parent = null, prev) {
+    var _a, _b;
+    if (typeof value !== "object" || value === null || STATE_SYMBOL in value) {
+      return value;
+    }
+    const prototype = get_prototype_of(value);
+    if (prototype !== object_prototype && prototype !== array_prototype) {
+      return value;
+    }
+    var sources = /* @__PURE__ */ new Map();
+    var is_proxied_array = is_array(value);
+    var version = source(0);
+    if (is_proxied_array) {
+      sources.set("length", source(
+        /** @type {any[]} */
+        value.length
+      ));
+    }
+    var metadata;
+    {
+      metadata = {
+        parent,
+        owners: null
+      };
+      if (prev) {
+        const prev_owners = (_b = (_a = prev.v) == null ? void 0 : _a[STATE_SYMBOL_METADATA]) == null ? void 0 : _b.owners;
+        metadata.owners = prev_owners ? new Set(prev_owners) : null;
+      } else {
+        metadata.owners = parent === null ? component_context !== null ? /* @__PURE__ */ new Set([component_context.function]) : null : /* @__PURE__ */ new Set();
+      }
+    }
+    return new Proxy(
+      /** @type {any} */
+      value,
+      {
+        defineProperty(_, prop, descriptor) {
+          if (!("value" in descriptor) || descriptor.configurable === false || descriptor.enumerable === false || descriptor.writable === false) {
+            state_descriptors_fixed();
+          }
+          var s = sources.get(prop);
+          if (s === void 0) {
+            s = source(descriptor.value);
+            sources.set(prop, s);
+          } else {
+            set(s, proxy(descriptor.value, metadata));
+          }
+          return true;
+        },
+        deleteProperty(target, prop) {
+          var s = sources.get(prop);
+          if (s === void 0) {
+            if (prop in target) {
+              sources.set(prop, source(UNINITIALIZED));
+            }
+          } else {
+            if (is_proxied_array && typeof prop === "string") {
+              var ls = (
+                /** @type {Source<number>} */
+                sources.get("length")
+              );
+              var n = Number(prop);
+              if (Number.isInteger(n) && n < ls.v) {
+                set(ls, n);
+              }
+            }
+            set(s, UNINITIALIZED);
+            update_version(version);
+          }
+          return true;
+        },
+        get(target, prop, receiver) {
+          var _a2;
+          if (prop === STATE_SYMBOL_METADATA) {
+            return metadata;
+          }
+          if (prop === STATE_SYMBOL) {
+            return value;
+          }
+          var s = sources.get(prop);
+          var exists = prop in target;
+          if (s === void 0 && (!exists || ((_a2 = get_descriptor(target, prop)) == null ? void 0 : _a2.writable))) {
+            s = source(proxy(exists ? target[prop] : UNINITIALIZED, metadata));
+            sources.set(prop, s);
+          }
+          if (s !== void 0) {
+            var v = get(s);
+            {
+              var prop_metadata = v == null ? void 0 : v[STATE_SYMBOL_METADATA];
+              if (prop_metadata && (prop_metadata == null ? void 0 : prop_metadata.parent) !== metadata) {
+                widen_ownership(metadata, prop_metadata);
+              }
+            }
+            return v === UNINITIALIZED ? void 0 : v;
+          }
+          return Reflect.get(target, prop, receiver);
+        },
+        getOwnPropertyDescriptor(target, prop) {
+          var descriptor = Reflect.getOwnPropertyDescriptor(target, prop);
+          if (descriptor && "value" in descriptor) {
+            var s = sources.get(prop);
+            if (s) descriptor.value = get(s);
+          } else if (descriptor === void 0) {
+            var source2 = sources.get(prop);
+            var value2 = source2 == null ? void 0 : source2.v;
+            if (source2 !== void 0 && value2 !== UNINITIALIZED) {
+              return {
+                enumerable: true,
+                configurable: true,
+                value: value2,
+                writable: true
+              };
+            }
+          }
+          return descriptor;
+        },
+        has(target, prop) {
+          var _a2;
+          if (prop === STATE_SYMBOL_METADATA) {
+            return true;
+          }
+          if (prop === STATE_SYMBOL) {
+            return true;
+          }
+          var s = sources.get(prop);
+          var has = s !== void 0 && s.v !== UNINITIALIZED || Reflect.has(target, prop);
+          if (s !== void 0 || active_effect !== null && (!has || ((_a2 = get_descriptor(target, prop)) == null ? void 0 : _a2.writable))) {
+            if (s === void 0) {
+              s = source(has ? proxy(target[prop], metadata) : UNINITIALIZED);
+              sources.set(prop, s);
+            }
+            var value2 = get(s);
+            if (value2 === UNINITIALIZED) {
+              return false;
+            }
+          }
+          return has;
+        },
+        set(target, prop, value2, receiver) {
+          var _a2;
+          var s = sources.get(prop);
+          var has = prop in target;
+          if (is_proxied_array && prop === "length") {
+            for (var i = value2; i < /** @type {Source<number>} */
+            s.v; i += 1) {
+              var other_s = sources.get(i + "");
+              if (other_s !== void 0) {
+                set(other_s, UNINITIALIZED);
+              } else if (i in target) {
+                other_s = source(UNINITIALIZED);
+                sources.set(i + "", other_s);
+              }
+            }
+          }
+          if (s === void 0) {
+            if (!has || ((_a2 = get_descriptor(target, prop)) == null ? void 0 : _a2.writable)) {
+              s = source(void 0);
+              set(s, proxy(value2, metadata));
+              sources.set(prop, s);
+            }
+          } else {
+            has = s.v !== UNINITIALIZED;
+            set(s, proxy(value2, metadata));
+          }
+          {
+            var prop_metadata = value2 == null ? void 0 : value2[STATE_SYMBOL_METADATA];
+            if (prop_metadata && (prop_metadata == null ? void 0 : prop_metadata.parent) !== metadata) {
+              widen_ownership(metadata, prop_metadata);
+            }
+            check_ownership(metadata);
+          }
+          var descriptor = Reflect.getOwnPropertyDescriptor(target, prop);
+          if (descriptor == null ? void 0 : descriptor.set) {
+            descriptor.set.call(receiver, value2);
+          }
+          if (!has) {
+            if (is_proxied_array && typeof prop === "string") {
+              var ls = (
+                /** @type {Source<number>} */
+                sources.get("length")
+              );
+              var n = Number(prop);
+              if (Number.isInteger(n) && n >= ls.v) {
+                set(ls, n + 1);
+              }
+            }
+            update_version(version);
+          }
+          return true;
+        },
+        ownKeys(target) {
+          get(version);
+          var own_keys = Reflect.ownKeys(target).filter((key2) => {
+            var source3 = sources.get(key2);
+            return source3 === void 0 || source3.v !== UNINITIALIZED;
+          });
+          for (var [key, source2] of sources) {
+            if (source2.v !== UNINITIALIZED && !(key in target)) {
+              own_keys.push(key);
+            }
+          }
+          return own_keys;
+        },
+        setPrototypeOf() {
+          state_prototype_fixed();
+        }
+      }
+    );
+  }
+  function update_version(signal, d = 1) {
+    set(signal, signal.v + d);
+  }
+  function get_proxied_value(value) {
+    if (value !== null && typeof value === "object" && STATE_SYMBOL in value) {
+      return value[STATE_SYMBOL];
+    }
+    return value;
+  }
+  function init_array_prototype_warnings() {
+    const array_prototype2 = Array.prototype;
+    const cleanup = Array.__svelte_cleanup;
+    if (cleanup) {
+      cleanup();
+    }
+    const { indexOf, lastIndexOf, includes } = array_prototype2;
+    array_prototype2.indexOf = function(item, from_index) {
+      const index = indexOf.call(this, item, from_index);
+      if (index === -1) {
+        for (let i = from_index ?? 0; i < this.length; i += 1) {
+          if (get_proxied_value(this[i]) === item) {
+            state_proxy_equality_mismatch("array.indexOf(...)");
+            break;
+          }
+        }
+      }
+      return index;
+    };
+    array_prototype2.lastIndexOf = function(item, from_index) {
+      const index = lastIndexOf.call(this, item, from_index ?? this.length - 1);
+      if (index === -1) {
+        for (let i = 0; i <= (from_index ?? this.length - 1); i += 1) {
+          if (get_proxied_value(this[i]) === item) {
+            state_proxy_equality_mismatch("array.lastIndexOf(...)");
+            break;
+          }
+        }
+      }
+      return index;
+    };
+    array_prototype2.includes = function(item, from_index) {
+      const has = includes.call(this, item, from_index);
+      if (!has) {
+        for (let i = 0; i < this.length; i += 1) {
+          if (get_proxied_value(this[i]) === item) {
+            state_proxy_equality_mismatch("array.includes(...)");
+            break;
+          }
+        }
+      }
+      return has;
+    };
+    Array.__svelte_cleanup = () => {
+      array_prototype2.indexOf = indexOf;
+      array_prototype2.lastIndexOf = lastIndexOf;
+      array_prototype2.includes = includes;
+    };
+  }
+  var $window;
+  var is_firefox;
+  var first_child_getter;
+  var next_sibling_getter;
+  function init_operations() {
+    if ($window !== void 0) {
+      return;
+    }
+    $window = window;
+    is_firefox = /Firefox/.test(navigator.userAgent);
+    var element_prototype = Element.prototype;
+    var node_prototype = Node.prototype;
+    first_child_getter = get_descriptor(node_prototype, "firstChild").get;
+    next_sibling_getter = get_descriptor(node_prototype, "nextSibling").get;
+    element_prototype.__click = void 0;
+    element_prototype.__className = void 0;
+    element_prototype.__attributes = null;
+    element_prototype.__styles = null;
+    element_prototype.__e = void 0;
+    Text.prototype.__t = void 0;
+    {
+      element_prototype.__svelte_meta = null;
+      init_array_prototype_warnings();
+    }
+  }
+  function create_text(value = "") {
+    return document.createTextNode(value);
+  }
+  // @__NO_SIDE_EFFECTS__
+  function get_first_child(node) {
+    return first_child_getter.call(node);
+  }
+  // @__NO_SIDE_EFFECTS__
+  function get_next_sibling(node) {
+    return next_sibling_getter.call(node);
+  }
+  function child(node, is_text) {
+    {
+      return /* @__PURE__ */ get_first_child(node);
+    }
+  }
+  const handled_errors = /* @__PURE__ */ new WeakSet();
+  let is_throwing_error = false;
+  let is_flushing = false;
+  let last_scheduled_effect = null;
+  let is_updating_effect = false;
+  let queued_root_effects = [];
+  let dev_effect_stack = [];
+  let active_reaction = null;
+  let untracking = false;
+  function set_active_reaction(reaction) {
+    active_reaction = reaction;
+  }
+  let active_effect = null;
+  function set_active_effect(effect2) {
+    active_effect = effect2;
+  }
+  let derived_sources = null;
+  function set_derived_sources(sources) {
+    derived_sources = sources;
+  }
+  let new_deps = null;
+  let skipped_deps = 0;
+  let untracked_writes = null;
+  function set_untracked_writes(value) {
+    untracked_writes = value;
+  }
+  let write_version = 1;
+  let read_version = 0;
+  let skip_reaction = false;
+  function increment_write_version() {
+    return ++write_version;
+  }
+  function check_dirtiness(reaction) {
+    var _a;
+    var flags = reaction.f;
+    if ((flags & DIRTY) !== 0) {
+      return true;
+    }
+    if ((flags & MAYBE_DIRTY) !== 0) {
+      var dependencies = reaction.deps;
+      var is_unowned = (flags & UNOWNED) !== 0;
+      if (dependencies !== null) {
+        var i;
+        var dependency;
+        var is_disconnected = (flags & DISCONNECTED) !== 0;
+        var is_unowned_connected = is_unowned && active_effect !== null && !skip_reaction;
+        var length = dependencies.length;
+        if (is_disconnected || is_unowned_connected) {
+          var derived2 = (
+            /** @type {Derived} */
+            reaction
+          );
+          var parent = derived2.parent;
+          for (i = 0; i < length; i++) {
+            dependency = dependencies[i];
+            if (is_disconnected || !((_a = dependency == null ? void 0 : dependency.reactions) == null ? void 0 : _a.includes(derived2))) {
+              (dependency.reactions ?? (dependency.reactions = [])).push(derived2);
+            }
+          }
+          if (is_disconnected) {
+            derived2.f ^= DISCONNECTED;
+          }
+          if (is_unowned_connected && parent !== null && (parent.f & UNOWNED) === 0) {
+            derived2.f ^= UNOWNED;
+          }
+        }
+        for (i = 0; i < length; i++) {
+          dependency = dependencies[i];
+          if (check_dirtiness(
+            /** @type {Derived} */
+            dependency
+          )) {
+            update_derived(
+              /** @type {Derived} */
+              dependency
+            );
+          }
+          if (dependency.wv > reaction.wv) {
+            return true;
+          }
+        }
+      }
+      if (!is_unowned || active_effect !== null && !skip_reaction) {
+        set_signal_status(reaction, CLEAN);
+      }
+    }
+    return false;
+  }
+  function propagate_error(error, effect2) {
+    var current = effect2;
+    while (current !== null) {
+      if ((current.f & BOUNDARY_EFFECT) !== 0) {
+        try {
+          current.fn(error);
+          return;
+        } catch {
+          current.f ^= BOUNDARY_EFFECT;
+        }
+      }
+      current = current.parent;
+    }
+    is_throwing_error = false;
+    throw error;
+  }
+  function should_rethrow_error(effect2) {
+    return (effect2.f & DESTROYED) === 0 && (effect2.parent === null || (effect2.parent.f & BOUNDARY_EFFECT) === 0);
+  }
+  function handle_error(error, effect2, previous_effect, component_context2) {
+    var _a, _b;
+    if (is_throwing_error) {
+      if (previous_effect === null) {
+        is_throwing_error = false;
+      }
+      if (should_rethrow_error(effect2)) {
+        throw error;
+      }
+      return;
+    }
+    if (previous_effect !== null) {
+      is_throwing_error = true;
+    }
+    if (component_context2 === null || !(error instanceof Error) || handled_errors.has(error)) {
+      propagate_error(error, effect2);
+      return;
+    }
+    handled_errors.add(error);
+    const component_stack = [];
+    const effect_name = (_a = effect2.fn) == null ? void 0 : _a.name;
+    if (effect_name) {
+      component_stack.push(effect_name);
+    }
+    let current_context = component_context2;
+    while (current_context !== null) {
+      {
+        var filename = (_b = current_context.function) == null ? void 0 : _b[FILENAME];
+        if (filename) {
+          const file = filename.split("/").pop();
+          component_stack.push(file);
+        }
+      }
+      current_context = current_context.p;
+    }
+    const indent = is_firefox ? "  " : "	";
+    define_property(error, "message", {
+      value: error.message + `
+${component_stack.map((name) => `
+${indent}in ${name}`).join("")}
+`
+    });
+    define_property(error, "component_stack", {
+      value: component_stack
+    });
+    const stack2 = error.stack;
+    if (stack2) {
+      const lines = stack2.split("\n");
+      const new_lines = [];
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        if (line.includes("svelte/src/internal")) {
+          continue;
+        }
+        new_lines.push(line);
+      }
+      define_property(error, "stack", {
+        value: new_lines.join("\n")
+      });
+    }
+    propagate_error(error, effect2);
+    if (should_rethrow_error(effect2)) {
+      throw error;
+    }
+  }
+  function schedule_possible_effect_self_invalidation(signal, effect2, root2 = true) {
+    var reactions = signal.reactions;
+    if (reactions === null) return;
+    for (var i = 0; i < reactions.length; i++) {
+      var reaction = reactions[i];
+      if ((reaction.f & DERIVED) !== 0) {
+        schedule_possible_effect_self_invalidation(
+          /** @type {Derived} */
+          reaction,
+          effect2,
+          false
+        );
+      } else if (effect2 === reaction) {
+        if (root2) {
+          set_signal_status(reaction, DIRTY);
+        } else if ((reaction.f & CLEAN) !== 0) {
+          set_signal_status(reaction, MAYBE_DIRTY);
+        }
+        schedule_effect(
+          /** @type {Effect} */
+          reaction
+        );
+      }
+    }
+  }
+  function update_reaction(reaction) {
+    var _a;
+    var previous_deps = new_deps;
+    var previous_skipped_deps = skipped_deps;
+    var previous_untracked_writes = untracked_writes;
+    var previous_reaction = active_reaction;
+    var previous_skip_reaction = skip_reaction;
+    var prev_derived_sources = derived_sources;
+    var previous_component_context = component_context;
+    var previous_untracking = untracking;
+    var flags = reaction.f;
+    new_deps = /** @type {null | Value[]} */
+    null;
+    skipped_deps = 0;
+    untracked_writes = null;
+    skip_reaction = (flags & UNOWNED) !== 0 && (untracking || !is_updating_effect || active_reaction === null);
+    active_reaction = (flags & (BRANCH_EFFECT | ROOT_EFFECT)) === 0 ? reaction : null;
+    derived_sources = null;
+    set_component_context(reaction.ctx);
+    untracking = false;
+    read_version++;
+    try {
+      var result = (
+        /** @type {Function} */
+        (0, reaction.fn)()
+      );
+      var deps = reaction.deps;
+      if (new_deps !== null) {
+        var i;
+        remove_reactions(reaction, skipped_deps);
+        if (deps !== null && skipped_deps > 0) {
+          deps.length = skipped_deps + new_deps.length;
+          for (i = 0; i < new_deps.length; i++) {
+            deps[skipped_deps + i] = new_deps[i];
+          }
+        } else {
+          reaction.deps = deps = new_deps;
+        }
+        if (!skip_reaction) {
+          for (i = skipped_deps; i < deps.length; i++) {
+            ((_a = deps[i]).reactions ?? (_a.reactions = [])).push(reaction);
+          }
+        }
+      } else if (deps !== null && skipped_deps < deps.length) {
+        remove_reactions(reaction, skipped_deps);
+        deps.length = skipped_deps;
+      }
+      if (is_runes() && untracked_writes !== null && !untracking && deps !== null && (reaction.f & (DERIVED | MAYBE_DIRTY | DIRTY)) === 0) {
+        for (i = 0; i < /** @type {Source[]} */
+        untracked_writes.length; i++) {
+          schedule_possible_effect_self_invalidation(
+            untracked_writes[i],
+            /** @type {Effect} */
+            reaction
+          );
+        }
+      }
+      if (previous_reaction !== null) {
+        read_version++;
+      }
+      return result;
+    } finally {
+      new_deps = previous_deps;
+      skipped_deps = previous_skipped_deps;
+      untracked_writes = previous_untracked_writes;
+      active_reaction = previous_reaction;
+      skip_reaction = previous_skip_reaction;
+      derived_sources = prev_derived_sources;
+      set_component_context(previous_component_context);
+      untracking = previous_untracking;
+    }
+  }
+  function remove_reaction(signal, dependency) {
+    let reactions = dependency.reactions;
+    if (reactions !== null) {
+      var index = index_of.call(reactions, signal);
+      if (index !== -1) {
+        var new_length = reactions.length - 1;
+        if (new_length === 0) {
+          reactions = dependency.reactions = null;
+        } else {
+          reactions[index] = reactions[new_length];
+          reactions.pop();
+        }
+      }
+    }
+    if (reactions === null && (dependency.f & DERIVED) !== 0 && // Destroying a child effect while updating a parent effect can cause a dependency to appear
+    // to be unused, when in fact it is used by the currently-updating parent. Checking `new_deps`
+    // allows us to skip the expensive work of disconnecting and immediately reconnecting it
+    (new_deps === null || !new_deps.includes(dependency))) {
+      set_signal_status(dependency, MAYBE_DIRTY);
+      if ((dependency.f & (UNOWNED | DISCONNECTED)) === 0) {
+        dependency.f ^= DISCONNECTED;
+      }
+      destroy_derived_effects(
+        /** @type {Derived} **/
+        dependency
+      );
+      remove_reactions(
+        /** @type {Derived} **/
+        dependency,
+        0
+      );
+    }
+  }
+  function remove_reactions(signal, start_index) {
+    var dependencies = signal.deps;
+    if (dependencies === null) return;
+    for (var i = start_index; i < dependencies.length; i++) {
+      remove_reaction(signal, dependencies[i]);
+    }
+  }
+  function update_effect(effect2) {
+    var flags = effect2.f;
+    if ((flags & DESTROYED) !== 0) {
+      return;
+    }
+    set_signal_status(effect2, CLEAN);
+    var previous_effect = active_effect;
+    var previous_component_context = component_context;
+    var was_updating_effect = is_updating_effect;
+    active_effect = effect2;
+    is_updating_effect = true;
+    {
+      var previous_component_fn = dev_current_component_function;
+      set_dev_current_component_function(effect2.component_function);
+    }
+    try {
+      if ((flags & BLOCK_EFFECT) !== 0) {
+        destroy_block_effect_children(effect2);
+      } else {
+        destroy_effect_children(effect2);
+      }
+      execute_effect_teardown(effect2);
+      var teardown2 = update_reaction(effect2);
+      effect2.teardown = typeof teardown2 === "function" ? teardown2 : null;
+      effect2.wv = write_version;
+      var deps = effect2.deps;
+      var dep;
+      if (DEV && tracing_mode_flag && (effect2.f & DIRTY) !== 0 && deps !== null) ;
+      if (DEV) {
+        dev_effect_stack.push(effect2);
+      }
+    } catch (error) {
+      handle_error(error, effect2, previous_effect, previous_component_context || effect2.ctx);
+    } finally {
+      is_updating_effect = was_updating_effect;
+      active_effect = previous_effect;
+      {
+        set_dev_current_component_function(previous_component_fn);
+      }
+    }
+  }
+  function log_effect_stack() {
+    console.error(
+      "Last ten effects were: ",
+      dev_effect_stack.slice(-10).map((d) => d.fn)
+    );
+    dev_effect_stack = [];
+  }
+  function infinite_loop_guard() {
+    try {
+      effect_update_depth_exceeded();
+    } catch (error) {
+      {
+        define_property(error, "stack", {
+          value: ""
+        });
+      }
+      if (last_scheduled_effect !== null) {
+        {
+          try {
+            handle_error(error, last_scheduled_effect, null, null);
+          } catch (e) {
+            log_effect_stack();
+            throw e;
+          }
+        }
+      } else {
+        {
+          log_effect_stack();
+        }
+        throw error;
+      }
+    }
+  }
+  function flush_queued_root_effects() {
+    try {
+      var flush_count = 0;
+      while (queued_root_effects.length > 0) {
+        if (flush_count++ > 1e3) {
+          infinite_loop_guard();
+        }
+        var root_effects = queued_root_effects;
+        var length = root_effects.length;
+        queued_root_effects = [];
+        for (var i = 0; i < length; i++) {
+          var root2 = root_effects[i];
+          if ((root2.f & CLEAN) === 0) {
+            root2.f ^= CLEAN;
+          }
+          var collected_effects = process_effects(root2);
+          flush_queued_effects(collected_effects);
+        }
+      }
+    } finally {
+      is_flushing = false;
+      last_scheduled_effect = null;
+      {
+        dev_effect_stack = [];
+      }
+    }
+  }
+  function flush_queued_effects(effects) {
+    var length = effects.length;
+    if (length === 0) return;
+    for (var i = 0; i < length; i++) {
+      var effect2 = effects[i];
+      if ((effect2.f & (DESTROYED | INERT)) === 0) {
+        try {
+          if (check_dirtiness(effect2)) {
+            update_effect(effect2);
+            if (effect2.deps === null && effect2.first === null && effect2.nodes_start === null) {
+              if (effect2.teardown === null) {
+                unlink_effect(effect2);
+              } else {
+                effect2.fn = null;
+              }
+            }
+          }
+        } catch (error) {
+          handle_error(error, effect2, null, effect2.ctx);
+        }
+      }
+    }
+  }
+  function schedule_effect(signal) {
+    if (!is_flushing) {
+      is_flushing = true;
+      queueMicrotask(flush_queued_root_effects);
+    }
+    var effect2 = last_scheduled_effect = signal;
+    while (effect2.parent !== null) {
+      effect2 = effect2.parent;
+      var flags = effect2.f;
+      if ((flags & (ROOT_EFFECT | BRANCH_EFFECT)) !== 0) {
+        if ((flags & CLEAN) === 0) return;
+        effect2.f ^= CLEAN;
+      }
+    }
+    queued_root_effects.push(effect2);
+  }
+  function process_effects(root2) {
+    var effects = [];
+    var effect2 = root2.first;
+    while (effect2 !== null) {
+      var flags = effect2.f;
+      var is_branch = (flags & BRANCH_EFFECT) !== 0;
+      var is_skippable_branch = is_branch && (flags & CLEAN) !== 0;
+      if (!is_skippable_branch && (flags & INERT) === 0) {
+        if ((flags & EFFECT) !== 0) {
+          effects.push(effect2);
+        } else if (is_branch) {
+          effect2.f ^= CLEAN;
+        } else {
+          var previous_active_reaction = active_reaction;
+          try {
+            active_reaction = effect2;
+            if (check_dirtiness(effect2)) {
+              update_effect(effect2);
+            }
+          } catch (error) {
+            handle_error(error, effect2, null, effect2.ctx);
+          } finally {
+            active_reaction = previous_active_reaction;
+          }
+        }
+        var child2 = effect2.first;
+        if (child2 !== null) {
+          effect2 = child2;
+          continue;
+        }
+      }
+      var parent = effect2.parent;
+      effect2 = effect2.next;
+      while (effect2 === null && parent !== null) {
+        effect2 = parent.next;
+        parent = parent.parent;
+      }
+    }
+    return effects;
+  }
+  function get(signal) {
+    var flags = signal.f;
+    var is_derived = (flags & DERIVED) !== 0;
+    if (active_reaction !== null && !untracking) {
+      if (derived_sources !== null && derived_sources.includes(signal)) {
+        state_unsafe_local_read();
+      }
+      var deps = active_reaction.deps;
+      if (signal.rv < read_version) {
+        signal.rv = read_version;
+        if (new_deps === null && deps !== null && deps[skipped_deps] === signal) {
+          skipped_deps++;
+        } else if (new_deps === null) {
+          new_deps = [signal];
+        } else if (!skip_reaction || !new_deps.includes(signal)) {
+          new_deps.push(signal);
+        }
+      }
+    } else if (is_derived && /** @type {Derived} */
+    signal.deps === null && /** @type {Derived} */
+    signal.effects === null) {
+      var derived2 = (
+        /** @type {Derived} */
+        signal
+      );
+      var parent = derived2.parent;
+      if (parent !== null && (parent.f & UNOWNED) === 0) {
+        derived2.f ^= UNOWNED;
+      }
+    }
+    if (is_derived) {
+      derived2 = /** @type {Derived} */
+      signal;
+      if (check_dirtiness(derived2)) {
+        update_derived(derived2);
+      }
+    }
+    return signal.v;
+  }
+  const STATUS_MASK = -7169;
+  function set_signal_status(signal, status) {
+    signal.f = signal.f & STATUS_MASK | status;
+  }
+  function push_effect(effect2, parent_effect) {
+    var parent_last = parent_effect.last;
+    if (parent_last === null) {
+      parent_effect.last = parent_effect.first = effect2;
+    } else {
+      parent_last.next = effect2;
+      effect2.prev = parent_last;
+      parent_effect.last = effect2;
+    }
+  }
+  function create_effect(type, fn, sync, push2 = true) {
+    var is_root = (type & ROOT_EFFECT) !== 0;
+    var parent_effect = active_effect;
+    {
+      while (parent_effect !== null && (parent_effect.f & INSPECT_EFFECT) !== 0) {
+        parent_effect = parent_effect.parent;
+      }
+    }
+    var effect2 = {
+      ctx: component_context,
+      deps: null,
+      nodes_start: null,
+      nodes_end: null,
+      f: type | DIRTY,
+      first: null,
+      fn,
+      last: null,
+      next: null,
+      parent: is_root ? null : parent_effect,
+      prev: null,
+      teardown: null,
+      transitions: null,
+      wv: 0
+    };
+    {
+      effect2.component_function = dev_current_component_function;
+    }
+    if (sync) {
+      try {
+        update_effect(effect2);
+        effect2.f |= EFFECT_RAN;
+      } catch (e) {
+        destroy_effect(effect2);
+        throw e;
+      }
+    } else if (fn !== null) {
+      schedule_effect(effect2);
+    }
+    var inert = sync && effect2.deps === null && effect2.first === null && effect2.nodes_start === null && effect2.teardown === null && (effect2.f & (EFFECT_HAS_DERIVED | BOUNDARY_EFFECT)) === 0;
+    if (!inert && !is_root && push2) {
+      if (parent_effect !== null) {
+        push_effect(effect2, parent_effect);
+      }
+      if (active_reaction !== null && (active_reaction.f & DERIVED) !== 0) {
+        var derived2 = (
+          /** @type {Derived} */
+          active_reaction
+        );
+        (derived2.effects ?? (derived2.effects = [])).push(effect2);
+      }
+    }
+    return effect2;
+  }
+  function teardown(fn) {
+    const effect2 = create_effect(RENDER_EFFECT, null, false);
+    set_signal_status(effect2, CLEAN);
+    effect2.teardown = fn;
+    return effect2;
+  }
+  function component_root(fn) {
+    const effect2 = create_effect(ROOT_EFFECT, fn, true);
+    return (options = {}) => {
+      return new Promise((fulfil) => {
+        if (options.outro) {
+          pause_effect(effect2, () => {
+            destroy_effect(effect2);
+            fulfil(void 0);
+          });
+        } else {
+          destroy_effect(effect2);
+          fulfil(void 0);
+        }
+      });
+    };
+  }
+  function effect(fn) {
+    return create_effect(EFFECT, fn, false);
+  }
+  function template_effect(fn, thunks = [], d = derived) {
+    const deriveds = thunks.map(d);
+    const effect2 = () => fn(...deriveds.map(get));
+    {
+      define_property(effect2, "name", {
+        value: "{expression}"
+      });
+    }
+    return block(effect2);
+  }
+  function block(fn, flags = 0) {
+    return create_effect(RENDER_EFFECT | BLOCK_EFFECT | flags, fn, true);
+  }
+  function branch(fn, push2 = true) {
+    return create_effect(RENDER_EFFECT | BRANCH_EFFECT, fn, true, push2);
+  }
+  function execute_effect_teardown(effect2) {
+    var teardown2 = effect2.teardown;
+    if (teardown2 !== null) {
+      const previous_reaction = active_reaction;
+      set_active_reaction(null);
+      try {
+        teardown2.call(null);
+      } finally {
+        set_active_reaction(previous_reaction);
+      }
+    }
+  }
+  function destroy_effect_children(signal, remove_dom = false) {
+    var effect2 = signal.first;
+    signal.first = signal.last = null;
+    while (effect2 !== null) {
+      var next = effect2.next;
+      destroy_effect(effect2, remove_dom);
+      effect2 = next;
+    }
+  }
+  function destroy_block_effect_children(signal) {
+    var effect2 = signal.first;
+    while (effect2 !== null) {
+      var next = effect2.next;
+      if ((effect2.f & BRANCH_EFFECT) === 0) {
+        destroy_effect(effect2);
+      }
+      effect2 = next;
+    }
+  }
+  function destroy_effect(effect2, remove_dom = true) {
+    var removed = false;
+    if ((remove_dom || (effect2.f & HEAD_EFFECT) !== 0) && effect2.nodes_start !== null) {
+      var node = effect2.nodes_start;
+      var end = effect2.nodes_end;
+      while (node !== null) {
+        var next = node === end ? null : (
+          /** @type {TemplateNode} */
+          /* @__PURE__ */ get_next_sibling(node)
+        );
+        node.remove();
+        node = next;
+      }
+      removed = true;
+    }
+    destroy_effect_children(effect2, remove_dom && !removed);
+    remove_reactions(effect2, 0);
+    set_signal_status(effect2, DESTROYED);
+    var transitions = effect2.transitions;
+    if (transitions !== null) {
+      for (const transition of transitions) {
+        transition.stop();
+      }
+    }
+    execute_effect_teardown(effect2);
+    var parent = effect2.parent;
+    if (parent !== null && parent.first !== null) {
+      unlink_effect(effect2);
+    }
+    {
+      effect2.component_function = null;
+    }
+    effect2.next = effect2.prev = effect2.teardown = effect2.ctx = effect2.deps = effect2.fn = effect2.nodes_start = effect2.nodes_end = null;
+  }
+  function unlink_effect(effect2) {
+    var parent = effect2.parent;
+    var prev = effect2.prev;
+    var next = effect2.next;
+    if (prev !== null) prev.next = next;
+    if (next !== null) next.prev = prev;
+    if (parent !== null) {
+      if (parent.first === effect2) parent.first = next;
+      if (parent.last === effect2) parent.last = prev;
+    }
+  }
+  function pause_effect(effect2, callback) {
+    var transitions = [];
+    pause_children(effect2, transitions, true);
+    run_out_transitions(transitions, () => {
+      destroy_effect(effect2);
+      if (callback) callback();
+    });
+  }
+  function run_out_transitions(transitions, fn) {
+    var remaining = transitions.length;
+    if (remaining > 0) {
+      var check = () => --remaining || fn();
+      for (var transition of transitions) {
+        transition.out(check);
+      }
+    } else {
+      fn();
+    }
+  }
+  function pause_children(effect2, transitions, local) {
+    if ((effect2.f & INERT) !== 0) return;
+    effect2.f ^= INERT;
+    if (effect2.transitions !== null) {
+      for (const transition of effect2.transitions) {
+        if (transition.is_global || local) {
+          transitions.push(transition);
+        }
+      }
+    }
+    var child2 = effect2.first;
+    while (child2 !== null) {
+      var sibling = child2.next;
+      var transparent = (child2.f & EFFECT_TRANSPARENT) !== 0 || (child2.f & BRANCH_EFFECT) !== 0;
+      pause_children(child2, transitions, transparent ? local : false);
+      child2 = sibling;
+    }
+  }
+  const boundaries = {};
+  const chrome_pattern = /at (?:.+ \()?(.+):(\d+):(\d+)\)?$/;
+  const firefox_pattern = /@(.+):(\d+):(\d+)$/;
+  function get_stack() {
+    const stack2 = new Error().stack;
+    if (!stack2) return null;
+    const entries = [];
+    for (const line of stack2.split("\n")) {
+      let match = chrome_pattern.exec(line) ?? firefox_pattern.exec(line);
+      if (match) {
+        entries.push({
+          file: match[1],
+          line: +match[2],
+          column: +match[3]
+        });
+      }
+    }
+    return entries;
+  }
+  function get_component() {
+    var _a;
+    const stack2 = (_a = get_stack()) == null ? void 0 : _a.slice(4);
+    if (!stack2) return null;
+    for (let i = 0; i < stack2.length; i++) {
+      const entry = stack2[i];
+      const modules = boundaries[entry.file];
+      if (!modules) {
+        if (i === 0) return null;
+        continue;
+      }
+      for (const module of modules) {
+        if (module.end == null) {
+          return null;
+        }
+        if (module.start.line < entry.line && module.end.line > entry.line) {
+          return module.component;
+        }
+      }
+    }
+    return null;
+  }
+  function mark_module_start() {
+    var _a, _b;
+    const start = (_a = get_stack()) == null ? void 0 : _a[2];
+    if (start) {
+      (boundaries[_b = start.file] ?? (boundaries[_b] = [])).push({
+        start,
+        // @ts-expect-error
+        end: null,
+        // @ts-expect-error we add the component at the end, since HMR will overwrite the function
+        component: null
+      });
+    }
+  }
+  function mark_module_end(component) {
+    var _a;
+    const end = (_a = get_stack()) == null ? void 0 : _a[2];
+    if (end) {
+      const boundaries_file = boundaries[end.file];
+      const boundary = boundaries_file[boundaries_file.length - 1];
+      boundary.end = end;
+      boundary.component = component;
+    }
+  }
+  function widen_ownership(from, to) {
+    if (to.owners === null) {
+      return;
+    }
+    while (from) {
+      if (from.owners === null) {
+        to.owners = null;
+        break;
+      }
+      for (const owner of from.owners) {
+        to.owners.add(owner);
+      }
+      from = from.parent;
+    }
+  }
+  function has_owner(metadata, component) {
+    if (metadata.owners === null) {
+      return true;
+    }
+    return metadata.owners.has(component) || // This helps avoid false positives when using HMR, where the component function is replaced
+    FILENAME in component && [...metadata.owners].some(
+      (owner) => (
+        /** @type {any} */
+        owner[FILENAME] === component[FILENAME]
+      )
+    ) || metadata.parent !== null && has_owner(metadata.parent, component);
+  }
+  function get_owner(metadata) {
+    var _a;
+    return ((_a = metadata == null ? void 0 : metadata.owners) == null ? void 0 : _a.values().next().value) ?? get_owner(
+      /** @type {ProxyMetadata} */
+      metadata.parent
+    );
+  }
+  function check_ownership(metadata) {
+    const component = get_component();
+    if (component && !has_owner(metadata, component)) {
+      let original = get_owner(metadata);
+      if (original[FILENAME] !== component[FILENAME]) {
+        ownership_invalid_mutation(component[FILENAME], original[FILENAME]);
+      } else {
+        ownership_invalid_mutation();
+      }
+    }
+  }
+  let component_context = null;
+  function set_component_context(context) {
+    component_context = context;
+  }
+  let dev_current_component_function = null;
+  function set_dev_current_component_function(fn) {
+    dev_current_component_function = fn;
+  }
+  function push(props, runes = false, fn) {
+    component_context = {
+      p: component_context,
+      c: null,
+      e: null,
+      m: false,
+      s: props,
+      x: null,
+      l: null
+    };
+    {
+      component_context.function = fn;
+      dev_current_component_function = fn;
+    }
+  }
+  function pop(component) {
+    var _a;
+    const context_stack_item = component_context;
+    if (context_stack_item !== null) {
+      if (component !== void 0) {
+        context_stack_item.x = component;
+      }
+      const component_effects = context_stack_item.e;
+      if (component_effects !== null) {
+        var previous_effect = active_effect;
+        var previous_reaction = active_reaction;
+        context_stack_item.e = null;
+        try {
+          for (var i = 0; i < component_effects.length; i++) {
+            var component_effect = component_effects[i];
+            set_active_effect(component_effect.effect);
+            set_active_reaction(component_effect.reaction);
+            effect(component_effect.fn);
+          }
+        } finally {
+          set_active_effect(previous_effect);
+          set_active_reaction(previous_reaction);
+        }
+      }
+      component_context = context_stack_item.p;
+      {
+        dev_current_component_function = ((_a = context_stack_item.p) == null ? void 0 : _a.function) ?? null;
+      }
+      context_stack_item.m = true;
+    }
+    return component || /** @type {T} */
+    {};
+  }
+  function is_runes() {
+    return true;
+  }
+  const PASSIVE_EVENTS = ["touchstart", "touchmove"];
+  function is_passive_event(name) {
+    return PASSIVE_EVENTS.includes(name);
+  }
+  function add_locations(fn, filename, locations) {
+    return (...args) => {
+      const dom = fn(...args);
+      var node = dom.nodeType === 11 ? dom.firstChild : dom;
+      assign_locations(node, filename, locations);
+      return dom;
+    };
+  }
+  function assign_location(element, filename, location) {
+    element.__svelte_meta = {
+      loc: { file: filename, line: location[0], column: location[1] }
+    };
+    if (location[2]) {
+      assign_locations(element.firstChild, filename, location[2]);
+    }
+  }
+  function assign_locations(node, filename, locations) {
+    var i = 0;
+    while (node && i < locations.length) {
+      if (node.nodeType === 1) {
+        assign_location(
+          /** @type {Element} */
+          node,
+          filename,
+          locations[i++]
+        );
+      }
+      node = node.nextSibling;
+    }
+  }
+  function listen(target, events, handler, call_handler_immediately = true) {
+    if (call_handler_immediately) {
+      handler();
+    }
+    for (var name of events) {
+      target.addEventListener(name, handler);
+    }
+    teardown(() => {
+      for (var name2 of events) {
+        target.removeEventListener(name2, handler);
+      }
+    });
+  }
+  function without_reactive_context(fn) {
+    var previous_reaction = active_reaction;
+    var previous_effect = active_effect;
+    set_active_reaction(null);
+    set_active_effect(null);
+    try {
+      return fn();
+    } finally {
+      set_active_reaction(previous_reaction);
+      set_active_effect(previous_effect);
+    }
+  }
+  const all_registered_events = /* @__PURE__ */ new Set();
+  const root_event_handles = /* @__PURE__ */ new Set();
+  function handle_event_propagation(event) {
+    var _a;
+    var handler_element = this;
+    var owner_document = (
+      /** @type {Node} */
+      handler_element.ownerDocument
+    );
+    var event_name = event.type;
+    var path = ((_a = event.composedPath) == null ? void 0 : _a.call(event)) || [];
+    var current_target = (
+      /** @type {null | Element} */
+      path[0] || event.target
+    );
+    var path_idx = 0;
+    var handled_at = event.__root;
+    if (handled_at) {
+      var at_idx = path.indexOf(handled_at);
+      if (at_idx !== -1 && (handler_element === document || handler_element === /** @type {any} */
+      window)) {
+        event.__root = handler_element;
+        return;
+      }
+      var handler_idx = path.indexOf(handler_element);
+      if (handler_idx === -1) {
+        return;
+      }
+      if (at_idx <= handler_idx) {
+        path_idx = at_idx;
+      }
+    }
+    current_target = /** @type {Element} */
+    path[path_idx] || event.target;
+    if (current_target === handler_element) return;
+    define_property(event, "currentTarget", {
+      configurable: true,
+      get() {
+        return current_target || owner_document;
+      }
+    });
+    var previous_reaction = active_reaction;
+    var previous_effect = active_effect;
+    set_active_reaction(null);
+    set_active_effect(null);
+    try {
+      var throw_error;
+      var other_errors = [];
+      while (current_target !== null) {
+        var parent_element = current_target.assignedSlot || current_target.parentNode || /** @type {any} */
+        current_target.host || null;
+        try {
+          var delegated = current_target["__" + event_name];
+          if (delegated !== void 0 && (!/** @type {any} */
+          current_target.disabled || // DOM could've been updated already by the time this is reached, so we check this as well
+          // -> the target could not have been disabled because it emits the event in the first place
+          event.target === current_target)) {
+            if (is_array(delegated)) {
+              var [fn, ...data2] = delegated;
+              fn.apply(current_target, [event, ...data2]);
+            } else {
+              delegated.call(current_target, event);
+            }
+          }
+        } catch (error) {
+          if (throw_error) {
+            other_errors.push(error);
+          } else {
+            throw_error = error;
+          }
+        }
+        if (event.cancelBubble || parent_element === handler_element || parent_element === null) {
+          break;
+        }
+        current_target = parent_element;
+      }
+      if (throw_error) {
+        for (let error of other_errors) {
+          queueMicrotask(() => {
+            throw error;
+          });
+        }
+        throw throw_error;
+      }
+    } finally {
+      event.__root = handler_element;
+      delete event.currentTarget;
+      set_active_reaction(previous_reaction);
+      set_active_effect(previous_effect);
+    }
+  }
+  function create_fragment_from_html(html) {
+    var elem = document.createElement("template");
+    elem.innerHTML = html;
+    return elem.content;
+  }
+  function assign_nodes(start, end) {
+    var effect2 = (
+      /** @type {Effect} */
+      active_effect
+    );
+    if (effect2.nodes_start === null) {
+      effect2.nodes_start = start;
+      effect2.nodes_end = end;
+    }
+  }
+  // @__NO_SIDE_EFFECTS__
+  function ns_template(content, flags, ns = "svg") {
+    var has_start = !content.startsWith("<!>");
+    var wrapped = `<${ns}>${has_start ? content : "<!>" + content}</${ns}>`;
+    var node;
+    return () => {
+      if (!node) {
+        var fragment = (
+          /** @type {DocumentFragment} */
+          create_fragment_from_html(wrapped)
+        );
+        var root2 = (
+          /** @type {Element} */
+          /* @__PURE__ */ get_first_child(fragment)
+        );
+        {
+          node = /** @type {Element} */
+          /* @__PURE__ */ get_first_child(root2);
+        }
+      }
+      var clone = (
+        /** @type {TemplateNode} */
+        node.cloneNode(true)
+      );
+      {
+        assign_nodes(clone, clone);
+      }
+      return clone;
+    };
+  }
+  function append(anchor, dom) {
+    if (anchor === null) {
+      return;
+    }
+    anchor.before(
+      /** @type {Node} */
+      dom
+    );
+  }
+  function mount(component, options) {
+    return _mount(component, options);
+  }
+  const document_listeners = /* @__PURE__ */ new Map();
+  function _mount(Component, { target, anchor, props = {}, events, context, intro = true }) {
+    init_operations();
+    var registered_events = /* @__PURE__ */ new Set();
+    var event_handle = (events2) => {
+      for (var i = 0; i < events2.length; i++) {
+        var event_name = events2[i];
+        if (registered_events.has(event_name)) continue;
+        registered_events.add(event_name);
+        var passive = is_passive_event(event_name);
+        target.addEventListener(event_name, handle_event_propagation, { passive });
+        var n = document_listeners.get(event_name);
+        if (n === void 0) {
+          document.addEventListener(event_name, handle_event_propagation, { passive });
+          document_listeners.set(event_name, 1);
+        } else {
+          document_listeners.set(event_name, n + 1);
+        }
+      }
+    };
+    event_handle(array_from(all_registered_events));
+    root_event_handles.add(event_handle);
+    var component = void 0;
+    var unmount = component_root(() => {
+      var anchor_node = anchor ?? target.appendChild(create_text());
+      branch(() => {
+        if (context) {
+          push({});
+          var ctx = (
+            /** @type {ComponentContext} */
+            component_context
+          );
+          ctx.c = context;
+        }
+        if (events) {
+          props.$$events = events;
+        }
+        component = Component(anchor_node, props) || {};
+        if (context) {
+          pop();
+        }
+      });
+      return () => {
+        var _a;
+        for (var event_name of registered_events) {
+          target.removeEventListener(event_name, handle_event_propagation);
+          var n = (
+            /** @type {number} */
+            document_listeners.get(event_name)
+          );
+          if (--n === 0) {
+            document.removeEventListener(event_name, handle_event_propagation);
+            document_listeners.delete(event_name);
+          } else {
+            document_listeners.set(event_name, n);
+          }
+        }
+        root_event_handles.delete(event_handle);
+        if (anchor_node !== anchor) {
+          (_a = anchor_node.parentNode) == null ? void 0 : _a.removeChild(anchor_node);
+        }
+      };
+    });
+    mounted_components.set(component, unmount);
+    return component;
+  }
+  let mounted_components = /* @__PURE__ */ new WeakMap();
+  function check_target(target) {
+    if (target) {
+      component_api_invalid_new(target[FILENAME] ?? "a component", target.name);
+    }
+  }
+  function legacy_api() {
+    const component = component_context == null ? void 0 : component_context.function;
+    function error(method) {
+      var _a;
+      const parent = ((_a = get_component()) == null ? void 0 : _a[FILENAME]) ?? "Something";
+      component_api_changed(parent, method, component[FILENAME]);
+    }
+    return {
+      $destroy: () => error("$destroy()"),
+      $on: () => error("$on(...)"),
+      $set: () => error("$set(...)")
+    };
+  }
+  function set_attribute(element, attribute, value, skip_warning) {
+    var attributes = element.__attributes ?? (element.__attributes = {});
+    if (attributes[attribute] === (attributes[attribute] = value)) return;
+    if (attribute === "style" && "__styles" in element) {
+      element.__styles = {};
+    }
+    if (attribute === "loading") {
+      element[LOADING_ATTR_SYMBOL] = value;
+    }
+    if (value == null) {
+      element.removeAttribute(attribute);
+    } else if (typeof value !== "string" && get_setters(element).includes(attribute)) {
+      element[attribute] = value;
+    } else {
+      element.setAttribute(attribute, value);
+    }
+  }
+  var setters_cache = /* @__PURE__ */ new Map();
+  function get_setters(element) {
+    var setters = setters_cache.get(element.nodeName);
+    if (setters) return setters;
+    setters_cache.set(element.nodeName, setters = []);
+    var descriptors;
+    var proto = element;
+    var element_proto = Element.prototype;
+    while (element_proto !== proto) {
+      descriptors = get_descriptors(proto);
+      for (var key in descriptors) {
+        if (descriptors[key].set) {
+          setters.push(key);
+        }
+      }
+      proto = get_prototype_of(proto);
+    }
+    return setters;
+  }
+  function bind_window_size(type, set2) {
+    listen(window, ["resize"], () => without_reactive_context(() => set2(window[type])));
+  }
+  {
+    let throw_rune_error = function(rune) {
+      if (!(rune in globalThis)) {
+        let value;
+        Object.defineProperty(globalThis, rune, {
+          configurable: true,
+          // eslint-disable-next-line getter-return
+          get: () => {
+            if (value !== void 0) {
+              return value;
+            }
+            rune_outside_svelte(rune);
+          },
+          set: (v) => {
+            value = v;
+          }
+        });
+      }
+    };
+    throw_rune_error("$state");
+    throw_rune_error("$effect");
+    throw_rune_error("$derived");
+    throw_rune_error("$inspect");
+    throw_rune_error("$props");
+    throw_rune_error("$bindable");
+  }
+  const PUBLIC_VERSION = "5";
+  if (typeof window !== "undefined")
+    (window.__svelte || (window.__svelte = { v: /* @__PURE__ */ new Set() })).v.add(PUBLIC_VERSION);
+  mark_module_start();
+  Viz[FILENAME] = "src/Viz.svelte";
+  var root = add_locations(/* @__PURE__ */ ns_template(`<svg><circle stroke="black"></circle></svg>`), Viz[FILENAME], [[9, 0, [[10, 2]]]]);
+  function Viz($$anchor, $$props) {
+    check_target(new.target);
+    push($$props, true, Viz);
+    let width = state$1(500);
+    let height = state$1(500);
+    var svg = root();
+    var circle = child(svg);
+    template_effect(() => {
+      set_attribute(svg, "width", get(width));
+      set_attribute(svg, "height", get(height));
+      set_attribute(circle, "cx", get(width) / 2);
+      set_attribute(circle, "cy", get(height) / 2);
+      set_attribute(circle, "r", $$props.radius);
+      set_attribute(circle, "fill", $$props.color);
+      set_attribute(circle, "stroke-width", $$props.stroke);
+    });
+    bind_window_size("innerWidth", ($$value) => set(width, proxy($$value, null, width)));
+    bind_window_size("innerHeight", ($$value) => set(height, proxy($$value, null, height)));
+    append($$anchor, svg);
+    return pop({ ...legacy_api() });
+  }
+  mark_module_end(Viz);
+  var data = {};
+  var state = { radius: 50, stroke: 2, color: "#ffffff" };
+  let reactiveState = proxy({ ...state });
+  function draw() {
+    reactiveState.data = data;
+    mount(Viz, {
+      target: document.body,
+      props: reactiveState
+      // Pass the reactive state to Svelte
+    });
+  }
+  function update() {
+    if (state.radius <= 0) throw new Error("Radius must be positive");
+    Object.assign(reactiveState, state);
+    reactiveState.data = data;
+  }
+  exports.data = data;
+  exports.draw = draw;
+  exports.state = state;
+  exports.update = update;
+  Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+  return exports;
+}({});

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,22 +1,23 @@
-import { defineConfig } from 'vite'
-import { resolve } from 'path'
-import { svelte } from '@sveltejs/vite-plugin-svelte'
+import { defineConfig } from 'vite';
+import { resolve } from 'path';
+import { svelte } from '@sveltejs/vite-plugin-svelte';
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [svelte()],
   build: {
     outDir: '',
+    minify: false,
     lib: {
       entry: resolve(__dirname, 'src/template.svelte.js'),
-      formats: [ 'iife'],
-      fileName:  'template.js',
-      name: 'template'
+      formats: ['iife'],
+      fileName: 'template.js',
+      name: 'template',
     },
     rollupOptions: {
       output: {
         entryFileNames: 'template.js',
       },
     },
- }
-})
+  },
+});


### PR DESCRIPTION
This PR implements a state handling pattern to integrate Svelte 5 rune based state with a serialisable state object as required by Flourish. The core solution involves maintaining two parallel objects:

1. A plain JavaScript object (`state`) with normal enumerable properties for Flourish
2. A reactive object (`reactiveState`) for Svelte's internal reactivity system

We sync them with `Object.assign()` whenever updates happen. This gives Flourish a serializable object it can work with while still leveraging Svelte's reactivity system.

Further changes:

- Added `.prettierrc` to maintain single quote formatting consistency (note, some other formatting still crosses over with your set-up)
- Updated `vite.config.js` to disable minification for improved debugging